### PR TITLE
Fix DuckDB native lib on Vercel (trace libduckdb.so)

### DIFF
--- a/frontend/lib/motherduck.ts
+++ b/frontend/lib/motherduck.ts
@@ -14,7 +14,12 @@ function connect(): Promise<DuckDBConnection> {
     // DUCKDB_PATH lets us point at a local .duckdb file for testing;
     // defaults to MotherDuck in production.
     const path = process.env.DUCKDB_PATH ?? "md:battlerap";
-    connPromise = DuckDBInstance.create(path).then((i) => i.connect());
+    // On serverless (Vercel/Lambda) only /tmp is writable, and DuckDB needs a
+    // home dir for extensions (incl. MotherDuck) + a temp dir for spills.
+    connPromise = DuckDBInstance.create(path, {
+      home_directory: "/tmp",
+      temp_directory: "/tmp",
+    }).then((i) => i.connect());
   }
   return connPromise;
 }

--- a/frontend/lib/motherduck.ts
+++ b/frontend/lib/motherduck.ts
@@ -11,15 +11,14 @@ let connPromise: Promise<DuckDBConnection> | null = null;
 
 function connect(): Promise<DuckDBConnection> {
   if (!connPromise) {
+    // On serverless (Vercel/Lambda) only /tmp is writable and HOME is empty,
+    // so DuckDB can't find a home dir for its extensions (incl. MotherDuck).
+    // Point HOME at /tmp before connecting; DuckDB reads it via getenv.
+    process.env.HOME ||= "/tmp";
     // DUCKDB_PATH lets us point at a local .duckdb file for testing;
     // defaults to MotherDuck in production.
     const path = process.env.DUCKDB_PATH ?? "md:battlerap";
-    // On serverless (Vercel/Lambda) only /tmp is writable, and DuckDB needs a
-    // home dir for extensions (incl. MotherDuck) + a temp dir for spills.
-    connPromise = DuckDBInstance.create(path, {
-      home_directory: "/tmp",
-      temp_directory: "/tmp",
-    }).then((i) => i.connect());
+    connPromise = DuckDBInstance.create(path).then((i) => i.connect());
   }
   return connPromise;
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   // DuckDB ships a native .node binary that can't be bundled; require it at
   // runtime instead (server-only, Node runtime).
   serverExternalPackages: ["@duckdb/node-api", "@duckdb/node-bindings"],
+
+  // The .node addon dynamically links libduckdb.so.1.4 (a ~110MB sibling),
+  // which file-tracing misses. Force the whole platform binary package into
+  // every server function so the shared lib is present at runtime.
+  outputFileTracingIncludes: {
+    "**": ["./node_modules/@duckdb/node-bindings-linux-x64/**/*"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Vercel deploy 500'd: `libduckdb.so.1.4: cannot open shared object file`. Next traced `duckdb.node` but not its ~110MB sibling shared lib. Force-include the platform binary package via `outputFileTracingIncludes` so both land in the serverless function.

Test via this PR's Vercel **preview** deployment before merging.