### PR TITLE
Fix incremental models stuck empty (NULL max)

### DIFF
--- a/dbt/models/mart/rappers_filtered.sql
+++ b/dbt/models/mart/rappers_filtered.sql
@@ -21,5 +21,6 @@ AND monthly_listeners > 1000000
 AND followers > 100000
 
 {% if is_incremental() %}
-    AND load_date > (select max(load_date) from {{ this }})
+    -- coalesce so an empty table (max = NULL) loads everything, not nothing
+    AND load_date > (select coalesce(max(load_date), timestamp '1900-01-01') from {{ this }})
 {% endif %}

--- a/dbt/models/staging/stg_results.sql
+++ b/dbt/models/staging/stg_results.sql
@@ -22,5 +22,6 @@ SELECT
 FROM results
 WHERE row_number = 1
 {% if is_incremental() %}
-    AND voted_at > (select max(voted_at) from {{ this }})
+    -- coalesce so an empty table (max = NULL) loads everything, not nothing
+    AND voted_at > (select coalesce(max(voted_at), timestamp '1900-01-01') from {{ this }})
 {% endif %}


### PR DESCRIPTION
`stg_results` (and `rappers_filtered`) were built incrementally while their source was empty, so `col > (select max(col) from this)` compared against NULL and matched nothing forever — empty stg_results → empty standings → empty rankings.

COALESCE the max to a floor date so an empty table loads everything. Reproduced the bug and verified the fix locally.