### PR TITLE
Ranking: tiebreak equal win rates by win count

### DIFF
--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -54,6 +54,6 @@ export async function getRanking(): Promise<RankingRow[]> {
   return query<RankingRow>(
     `SELECT artist_id, artist_name, monthly_listeners, followers, wins, losses, win_rate
      FROM mart.rankings
-     ORDER BY win_rate DESC`,
+     ORDER BY win_rate DESC, wins DESC`,
   );
 }


### PR DESCRIPTION
`ORDER BY win_rate DESC` alone left all 100%-win-rate artists tied in arbitrary order (Pusha T 12-0 above Drake 15-0). Add `wins DESC` as a tiebreaker.

(This is the tiebreaker that missed the #15 merge window.)