### PR TITLE
UI polish: hover previews, snappier voting, ranking + font glow-up

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -10,7 +10,8 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-accent: var(--accent);
-  --font-sans: var(--font-poppins);
+  --font-sans: var(--font-inter);
+  --font-display: var(--font-space-grotesk);
 }
 
 body {
@@ -18,5 +19,13 @@ body {
     radial-gradient(1100px 550px at 50% -12%, rgba(29, 185, 84, 0.14), transparent 60%),
     var(--background);
   color: var(--foreground);
-  font-family: var(--font-poppins), system-ui, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
+}
+
+/* headings get the display face + tighter tracking for a modern feel */
+h1,
+h2,
+h3 {
+  font-family: var(--font-space-grotesk), system-ui, sans-serif;
+  letter-spacing: -0.02em;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
-import { Poppins } from "next/font/google";
+import { Space_Grotesk, Inter } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 
-const poppins = Poppins({
-  variable: "--font-poppins",
-  weight: ["400", "500", "600", "700"],
+const spaceGrotesk = Space_Grotesk({
+  variable: "--font-space-grotesk",
+  weight: ["500", "600", "700"],
+  subsets: ["latin"],
+});
+
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -21,7 +26,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${poppins.variable} h-full antialiased`}>
+    <html
+      lang="en"
+      className={`${spaceGrotesk.variable} ${inter.variable} h-full antialiased`}
+    >
       <body className="min-h-full flex flex-col">
         <Navbar />
         <main className="flex-1">{children}</main>

--- a/frontend/app/ranking/page.tsx
+++ b/frontend/app/ranking/page.tsx
@@ -2,15 +2,16 @@ import { getRanking } from "@/lib/data";
 
 export const dynamic = "force-dynamic";
 
-function fmt(n: number) {
-  return new Intl.NumberFormat("en-US").format(n);
-}
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
 
 export default async function RankingPage() {
   const rows = await getRanking();
 
   return (
-    <section className="mx-auto max-w-5xl px-4 py-10">
+    <section className="mx-auto max-w-4xl px-4 py-10">
       <h1 className="mb-6 text-3xl font-bold">Ranking</h1>
       <div className="overflow-x-auto rounded-2xl border border-white/10">
         <table className="w-full text-sm">
@@ -19,10 +20,9 @@ export default async function RankingPage() {
               <th className="px-4 py-3 font-medium">#</th>
               <th className="px-4 py-3 font-medium">Artist</th>
               <th className="px-4 py-3 text-right font-medium">Monthly Listeners</th>
-              <th className="px-4 py-3 text-right font-medium">Followers</th>
               <th className="px-4 py-3 text-right font-medium">Wins</th>
               <th className="px-4 py-3 text-right font-medium">Losses</th>
-              <th className="px-4 py-3 text-right font-medium">Win Rate</th>
+              <th className="px-4 py-3 font-medium">Win Rate</th>
             </tr>
           </thead>
           <tbody>
@@ -31,14 +31,27 @@ export default async function RankingPage() {
                 key={r.artist_id}
                 className="border-t border-white/5 transition hover:bg-white/5"
               >
-                <td className="px-4 py-3 text-white/50">{i + 1}</td>
+                <td className="px-4 py-3 tabular-nums text-white/50">{i + 1}</td>
                 <td className="px-4 py-3 font-medium">{r.artist_name}</td>
-                <td className="px-4 py-3 text-right tabular-nums">{fmt(r.monthly_listeners)}</td>
-                <td className="px-4 py-3 text-right tabular-nums">{fmt(r.followers)}</td>
+                <td className="px-4 py-3 text-right tabular-nums">
+                  {compact.format(r.monthly_listeners)}
+                </td>
                 <td className="px-4 py-3 text-right tabular-nums">{r.wins}</td>
                 <td className="px-4 py-3 text-right tabular-nums">{r.losses}</td>
-                <td className="px-4 py-3 text-right tabular-nums">
-                  {(r.win_rate * 100).toFixed(1)}%
+                <td className="px-4 py-3">
+                  {/* bar fills to win rate; hue shifts red -> green with the value */}
+                  <div className="relative h-6 w-28 overflow-hidden rounded-md bg-white/5">
+                    <div
+                      className="absolute inset-y-0 left-0"
+                      style={{
+                        width: `${r.win_rate * 100}%`,
+                        backgroundColor: `hsl(${r.win_rate * 120} 65% 45% / 0.55)`,
+                      }}
+                    />
+                    <span className="absolute inset-0 grid place-items-center text-xs font-semibold tabular-nums">
+                      {(r.win_rate * 100).toFixed(0)}%
+                    </span>
+                  </div>
                 </td>
               </tr>
             ))}

--- a/frontend/components/VoteArena.tsx
+++ b/frontend/components/VoteArena.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Matchup, Rapper, Track } from "@/lib/types";
 
-function fmt(n: number) {
-  return new Intl.NumberFormat("en-US").format(n);
-}
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
 
 function RapperCard({
   rapper,
@@ -22,11 +23,61 @@ function RapperCard({
   disabled: boolean;
   onPick: () => void;
 }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const fadeRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ramp volume toward a target for a smooth crossfade in/out
+  const fadeTo = useCallback((target: number, onDone?: () => void) => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (fadeRef.current) clearInterval(fadeRef.current);
+    fadeRef.current = setInterval(() => {
+      const step = 0.08;
+      if (Math.abs(el.volume - target) <= step) {
+        el.volume = target;
+        if (fadeRef.current) clearInterval(fadeRef.current);
+        onDone?.();
+      } else {
+        el.volume += el.volume < target ? step : -step;
+      }
+    }, 40);
+  }, []);
+
+  const startPreview = useCallback(() => {
+    const el = audioRef.current;
+    if (!el || !rapper.preview_url) return;
+    el.currentTime = 0;
+    el.volume = 0;
+    el.play().then(() => fadeTo(0.85)).catch(() => {}); // ignore autoplay blocks
+  }, [rapper.preview_url, fadeTo]);
+
+  const stopPreview = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    fadeTo(0, () => el.pause());
+  }, [fadeTo]);
+
+  // cleanup on unmount / matchup swap
+  useEffect(
+    () => () => {
+      if (fadeRef.current) clearInterval(fadeRef.current);
+      audioRef.current?.pause();
+    },
+    [],
+  );
+
   return (
-    <div className={`flex flex-col gap-3 transition duration-300 ${dimmed ? "opacity-40" : "opacity-100"}`}>
+    <div
+      className={`flex flex-col gap-3 transition duration-300 ${dimmed ? "opacity-40" : "opacity-100"}`}
+    >
+      {rapper.preview_url && (
+        <audio ref={audioRef} src={rapper.preview_url} preload="none" />
+      )}
       <button
         type="button"
         onClick={onPick}
+        onMouseEnter={startPreview}
+        onMouseLeave={stopPreview}
         disabled={disabled}
         className={`group relative aspect-square w-full overflow-hidden rounded-2xl border-2 transition duration-200
           ${picked ? "border-accent shadow-[0_0_40px_-8px_var(--accent)]" : "border-white/10"}
@@ -40,7 +91,9 @@ function RapperCard({
         />
         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 to-transparent p-4 text-left">
           <h2 className="text-2xl font-bold leading-tight">{rapper.artist_name}</h2>
-          <p className="text-sm text-white/70">{fmt(rapper.monthly_listeners)} monthly listeners</p>
+          <p className="text-sm text-white/70">
+            {compact.format(rapper.monthly_listeners)} monthly listeners
+          </p>
         </div>
         {rapper.world_rank != null && rapper.world_rank > 0 && (
           <div
@@ -74,29 +127,45 @@ export function VoteArena({ initial }: { initial: Matchup }) {
   const [matchup, setMatchup] = useState<Matchup>(initial);
   const [picked, setPicked] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // the next matchup, fetched in the background so voting swaps instantly
+  const nextRef = useRef<Promise<Matchup | null> | null>(null);
+
+  const prefetch = useCallback(() => {
+    nextRef.current = fetch("/api/matchup", { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<Matchup>) : null))
+      .catch(() => null);
+  }, []);
+
+  useEffect(() => {
+    prefetch();
+  }, [prefetch]);
 
   async function vote(winner: Rapper, loser: Rapper) {
     if (busy) return;
     setBusy(true);
     setPicked(winner.artist_id);
 
-    try {
-      await fetch("/api/vote", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ winner_id: winner.artist_id, loser_id: loser.artist_id }),
-      });
-      // brief beat so the pick animation reads before swapping
-      await new Promise((r) => setTimeout(r, 450));
-      const next = await fetch("/api/matchup", { cache: "no-store" });
-      if (!next.ok) throw new Error("matchup fetch failed");
-      setMatchup((await next.json()) as Matchup);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setPicked(null);
-      setBusy(false);
+    // fire-and-forget the vote — don't make the user wait on the write
+    fetch("/api/vote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ winner_id: winner.artist_id, loser_id: loser.artist_id }),
+    }).catch(() => {});
+
+    // short beat so the pick animation reads
+    await new Promise((r) => setTimeout(r, 350));
+
+    let next = await (nextRef.current ?? Promise.resolve(null));
+    if (!next) {
+      next = await fetch("/api/matchup", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
     }
+    if (next) setMatchup(next);
+    prefetch(); // queue the following matchup
+
+    setPicked(null);
+    setBusy(false);
   }
 
   const { rapper1, rapper2, tracks1, tracks2 } = matchup;
@@ -123,7 +192,7 @@ export function VoteArena({ initial }: { initial: Matchup }) {
         />
       </div>
       <p className="mt-8 text-center text-sm text-white/40">
-        Tap a rapper to cast your vote. Preview their top tracks below each.
+        Tap a rapper to vote — or hover for a taste. Top tracks preview below each.
       </p>
     </section>
   );

--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -38,8 +38,37 @@ export async function getMatchup(): Promise<Matchup> {
     topTracks(rapper1.artist_id),
     topTracks(rapper2.artist_id),
   ]);
+  const [preview1, preview2] = await Promise.all([
+    topPreviewUrl(tracks1[0]?.track_id),
+    topPreviewUrl(tracks2[0]?.track_id),
+  ]);
 
-  return { rapper1, rapper2, tracks1, tracks2 };
+  return {
+    rapper1: { ...rapper1, preview_url: preview1 },
+    rapper2: { ...rapper2, preview_url: preview2 },
+    tracks1,
+    tracks2,
+  };
+}
+
+// The 30s preview MP3 isn't exposed by the API anymore; scrape it from the
+// track's embed page (same __NEXT_DATA__ trick as the playlist reader).
+async function topPreviewUrl(trackId?: string): Promise<string | null> {
+  if (!trackId) return null;
+  try {
+    const res = await fetch(`https://open.spotify.com/embed/track/${trackId}`, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+    });
+    const html = await res.text();
+    const m = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    if (!m) return null;
+    const data = JSON.parse(m[1]);
+    return data?.props?.pageProps?.state?.data?.entity?.audioPreview?.url ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function recordVote(winnerId: string, loserId: string): Promise<void> {
@@ -52,7 +81,7 @@ export async function recordVote(winnerId: string, loserId: string): Promise<voi
 
 export async function getRanking(): Promise<RankingRow[]> {
   return query<RankingRow>(
-    `SELECT artist_id, artist_name, monthly_listeners, followers, wins, losses, win_rate
+    `SELECT artist_id, artist_name, monthly_listeners, wins, losses, win_rate
      FROM mart.rankings
      ORDER BY win_rate DESC, wins DESC`,
   );

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -5,6 +5,7 @@ export type Rapper = {
   followers: number;
   world_rank: number | null;
   image_url: string | null;
+  preview_url: string | null; // 30s clip of the artist's top track (hover preview)
 };
 
 export type Track = {
@@ -26,7 +27,6 @@ export type RankingRow = {
   artist_id: string;
   artist_name: string;
   monthly_listeners: number;
-  followers: number;
   wins: number;
   losses: number;
   win_rate: number;


### PR DESCRIPTION
Fun batch:
- **Hover preview** — hover a rapper's picture → crossfade-play a 30s clip of their top track. Preview MP3 scraped from the track embed (`audioPreview.url`), attached in `getMatchup`.
- **Snappier voting** — prefetch the next matchup + fire-and-forget the vote write → instant swap after a short animation beat (was ~1-2s).
- **Ranking** — dropped the followers column; compact numbers (`39.5M`); win-rate as a value-colored (red→green) fill bar.
- **Font** — Space Grotesk (display) + Inter (body).

Preview URLs verified populating live.