### PR TITLE
Live rankings + table glow-up

### DIFF
--- a/frontend/app/ranking/page.tsx
+++ b/frontend/app/ranking/page.tsx
@@ -7,6 +7,8 @@ const compact = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
 });
 
+const MEDALS = ["🥇", "🥈", "🥉"];
+
 export default async function RankingPage() {
   const rows = await getRanking();
 
@@ -17,7 +19,7 @@ export default async function RankingPage() {
         <table className="w-full text-sm">
           <thead className="bg-white/5 text-left text-white/60">
             <tr>
-              <th className="px-4 py-3 font-medium">#</th>
+              <th className="w-12 px-4 py-3 text-center font-medium">#</th>
               <th className="px-4 py-3 font-medium">Artist</th>
               <th className="px-4 py-3 text-right font-medium">Monthly Listeners</th>
               <th className="px-4 py-3 text-right font-medium">Wins</th>
@@ -29,17 +31,30 @@ export default async function RankingPage() {
             {rows.map((r, i) => (
               <tr
                 key={r.artist_id}
-                className="border-t border-white/5 transition hover:bg-white/5"
+                className={`border-t border-white/5 transition hover:bg-white/5 ${
+                  i < 3 ? "bg-accent/[0.04]" : ""
+                }`}
               >
-                <td className="px-4 py-3 tabular-nums text-white/50">{i + 1}</td>
-                <td className="px-4 py-3 font-medium">{r.artist_name}</td>
+                <td className="px-4 py-3 text-center text-lg tabular-nums text-white/50">
+                  {i < 3 ? MEDALS[i] : i + 1}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={r.image_url ?? ""}
+                      alt={r.artist_name}
+                      className="h-9 w-9 shrink-0 rounded-full object-cover ring-1 ring-white/10"
+                    />
+                    <span className="font-medium">{r.artist_name}</span>
+                  </div>
+                </td>
                 <td className="px-4 py-3 text-right tabular-nums">
                   {compact.format(r.monthly_listeners)}
                 </td>
                 <td className="px-4 py-3 text-right tabular-nums">{r.wins}</td>
                 <td className="px-4 py-3 text-right tabular-nums">{r.losses}</td>
                 <td className="px-4 py-3">
-                  {/* bar fills to win rate; hue shifts red -> green with the value */}
                   <div className="relative h-6 w-28 overflow-hidden rounded-md bg-white/5">
                     <div
                       className="absolute inset-y-0 left-0"

--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -79,10 +79,30 @@ export async function recordVote(winnerId: string, loserId: string): Promise<voi
   );
 }
 
+// Live leaderboard: aggregate votes straight from raw.results (updates the
+// instant a vote lands) and join to the daily-built rapper stats. No dbt run
+// needed for standings to move.
 export async function getRanking(): Promise<RankingRow[]> {
   return query<RankingRow>(
-    `SELECT artist_id, artist_name, monthly_listeners, wins, losses, win_rate
-     FROM mart.rankings
+    `WITH wins AS (
+       SELECT winner_id AS artist_id, count(*) AS wins FROM raw.results GROUP BY 1
+     ),
+     losses AS (
+       SELECT loser_id AS artist_id, count(*) AS losses FROM raw.results GROUP BY 1
+     )
+     SELECT
+       r.artist_id,
+       r.artist_name,
+       r.monthly_listeners,
+       r.image_url,
+       coalesce(w.wins, 0) AS wins,
+       coalesce(l.losses, 0) AS losses,
+       coalesce(w.wins, 0)::double
+         / nullif(coalesce(w.wins, 0) + coalesce(l.losses, 0), 0) AS win_rate
+     FROM mart.rappers r
+     LEFT JOIN wins w USING (artist_id)
+     LEFT JOIN losses l USING (artist_id)
+     WHERE coalesce(w.wins, 0) + coalesce(l.losses, 0) > 0
      ORDER BY win_rate DESC, wins DESC`,
   );
 }

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -27,6 +27,7 @@ export type RankingRow = {
   artist_id: string;
   artist_name: string;
   monthly_listeners: number;
+  image_url: string | null;
   wins: number;
   losses: number;
   win_rate: number;


### PR DESCRIPTION
- **Live standings**: `getRanking()` now aggregates votes straight from `raw.results` (joined to daily-built rapper stats), so the leaderboard moves the instant a vote lands — no dbt run needed.
- **Table glow-up**: artist avatars, 🥇🥈🥉 for the podium, subtle top-3 row tint.