### PR TITLE
Land ranking UX (#21) + fix DB concurrency 500s

### DIFF
--- a/frontend/app/ranking/page.tsx
+++ b/frontend/app/ranking/page.tsx
@@ -1,13 +1,7 @@
 import { getRanking } from "@/lib/data";
+import { RankingTable } from "@/components/RankingTable";
 
 export const dynamic = "force-dynamic";
-
-const compact = new Intl.NumberFormat("en-US", {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
-
-const MEDALS = ["🥇", "🥈", "🥉"];
 
 export default async function RankingPage() {
   const rows = await getRanking();
@@ -15,64 +9,7 @@ export default async function RankingPage() {
   return (
     <section className="mx-auto max-w-4xl px-4 py-10">
       <h1 className="mb-6 text-3xl font-bold">Ranking</h1>
-      <div className="overflow-x-auto rounded-2xl border border-white/10">
-        <table className="w-full text-sm">
-          <thead className="bg-white/5 text-left text-white/60">
-            <tr>
-              <th className="w-12 px-4 py-3 text-center font-medium">#</th>
-              <th className="px-4 py-3 font-medium">Artist</th>
-              <th className="px-4 py-3 text-right font-medium">Monthly Listeners</th>
-              <th className="px-4 py-3 text-right font-medium">Wins</th>
-              <th className="px-4 py-3 text-right font-medium">Losses</th>
-              <th className="px-4 py-3 font-medium">Win Rate</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r, i) => (
-              <tr
-                key={r.artist_id}
-                className={`border-t border-white/5 transition hover:bg-white/5 ${
-                  i < 3 ? "bg-accent/[0.04]" : ""
-                }`}
-              >
-                <td className="px-4 py-3 text-center text-lg tabular-nums text-white/50">
-                  {i < 3 ? MEDALS[i] : i + 1}
-                </td>
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-3">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={r.image_url ?? ""}
-                      alt={r.artist_name}
-                      className="h-9 w-9 shrink-0 rounded-full object-cover ring-1 ring-white/10"
-                    />
-                    <span className="font-medium">{r.artist_name}</span>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums">
-                  {compact.format(r.monthly_listeners)}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums">{r.wins}</td>
-                <td className="px-4 py-3 text-right tabular-nums">{r.losses}</td>
-                <td className="px-4 py-3">
-                  <div className="relative h-6 w-28 overflow-hidden rounded-md bg-white/5">
-                    <div
-                      className="absolute inset-y-0 left-0"
-                      style={{
-                        width: `${r.win_rate * 100}%`,
-                        backgroundColor: `hsl(${r.win_rate * 120} 65% 45% / 0.55)`,
-                      }}
-                    />
-                    <span className="absolute inset-0 grid place-items-center text-xs font-semibold tabular-nums">
-                      {(r.win_rate * 100).toFixed(0)}%
-                    </span>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <RankingTable rows={rows} />
     </section>
   );
 }

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 
 const links = [
-  { href: "/about", label: "About" },
   { href: "/ranking", label: "Ranking" },
   { href: "/visualize", label: "Visualize" },
   { href: "https://github.com/fuwilliam/battle-rap", label: "Github", external: true },
+  { href: "/about", label: "About" },
 ];
 
 export function Navbar() {

--- a/frontend/components/RankingTable.tsx
+++ b/frontend/components/RankingTable.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { RankingRow } from "@/lib/types";
+
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const MEDALS = ["🥇", "🥈", "🥉"];
+const PAGE = 50;
+
+type SortKey = "monthly_listeners" | "wins" | "losses" | "win_rate";
+
+const COLS: { key: SortKey; label: string }[] = [
+  { key: "monthly_listeners", label: "Monthly Listeners" },
+  { key: "wins", label: "Wins" },
+  { key: "losses", label: "Losses" },
+  { key: "win_rate", label: "Win Rate" },
+];
+
+export function RankingTable({ rows }: { rows: RankingRow[] }) {
+  // canonical battle rank from the incoming (win_rate desc, wins desc) order;
+  // it stays glued to each artist even when the view is re-sorted
+  const ranked = useMemo(() => rows.map((r, i) => ({ ...r, rank: i + 1 })), [rows]);
+
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [dir, setDir] = useState<"asc" | "desc">("desc");
+  const [expanded, setExpanded] = useState(false);
+
+  const sorted = useMemo(() => {
+    if (!sortKey) return ranked;
+    return [...ranked].sort(
+      (a, b) => (a[sortKey] - b[sortKey]) * (dir === "asc" ? 1 : -1),
+    );
+  }, [ranked, sortKey, dir]);
+
+  const visible = expanded ? sorted : sorted.slice(0, PAGE);
+
+  function toggleSort(k: SortKey) {
+    if (sortKey === k) setDir((d) => (d === "asc" ? "desc" : "asc"));
+    else {
+      setSortKey(k);
+      setDir("desc");
+    }
+  }
+
+  const arrow = (k: SortKey) => (sortKey === k ? (dir === "asc" ? " ▲" : " ▼") : "");
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-2xl border border-white/10">
+        <table className="w-full text-sm">
+          <thead className="bg-white/5 text-left text-white/60">
+            <tr>
+              <th className="w-12 px-4 py-3 text-center font-medium">#</th>
+              <th className="px-4 py-3 font-medium">Artist</th>
+              {COLS.map((c) => (
+                <th
+                  key={c.key}
+                  className={`px-4 py-3 font-medium ${c.key === "win_rate" ? "" : "text-right"}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleSort(c.key)}
+                    className="tabular-nums transition hover:text-white"
+                  >
+                    {c.label}
+                    {arrow(c.key)}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((r) => (
+              <tr
+                key={r.artist_id}
+                className={`border-t border-white/5 transition hover:bg-white/5 ${
+                  r.rank <= 3 ? "bg-accent/[0.04]" : ""
+                }`}
+              >
+                <td className="px-4 py-3 text-center text-lg tabular-nums text-white/50">
+                  {r.rank <= 3 ? MEDALS[r.rank - 1] : r.rank}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={r.image_url ?? ""}
+                      alt={r.artist_name}
+                      className="h-9 w-9 shrink-0 rounded-full object-cover ring-1 ring-white/10"
+                    />
+                    <span className="font-medium">{r.artist_name}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums">
+                  {compact.format(r.monthly_listeners)}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums">{r.wins}</td>
+                <td className="px-4 py-3 text-right tabular-nums">{r.losses}</td>
+                <td className="px-4 py-3">
+                  <div className="relative h-6 w-28 overflow-hidden rounded-md bg-white/5">
+                    <div
+                      className="absolute inset-y-0 left-0"
+                      style={{
+                        width: `${r.win_rate * 100}%`,
+                        backgroundColor: `hsl(${r.win_rate * 120} 65% 45% / 0.55)`,
+                      }}
+                    />
+                    <span className="absolute inset-0 grid place-items-center text-xs font-semibold tabular-nums">
+                      {(r.win_rate * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {sorted.length > PAGE && (
+        <div className="mt-4 text-center">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="rounded-lg border border-white/10 px-4 py-2 text-sm text-white/70 transition hover:bg-white/5 hover:text-white"
+          >
+            {expanded ? "Show top 50" : `Show all ${sorted.length}`}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/lib/motherduck.ts
+++ b/frontend/lib/motherduck.ts
@@ -1,26 +1,23 @@
-import {
-  DuckDBInstance,
-  type DuckDBConnection,
-  type DuckDBValue,
-} from "@duckdb/node-api";
+import { DuckDBInstance, type DuckDBValue } from "@duckdb/node-api";
 
-// Server-only. One lazily-created MotherDuck connection, reused within a warm
-// server instance. Auth comes from the `motherduck_token` env var, which the
-// DuckDB MotherDuck extension reads automatically for `md:` paths.
-let connPromise: Promise<DuckDBConnection> | null = null;
+// Server-only. Share ONE MotherDuck instance (the database handle) but give
+// every operation its own short-lived connection. A DuckDB connection can't
+// run statements concurrently, so a single shared connection breaks when a
+// vote write and the next matchup read overlap ("Failed to execute prepared
+// statement"). Separate connections off one instance run safely in parallel.
+// Auth: the `motherduck_token` env var, read automatically for `md:` paths.
+let instancePromise: Promise<DuckDBInstance> | null = null;
 
-function connect(): Promise<DuckDBConnection> {
-  if (!connPromise) {
+function getInstance(): Promise<DuckDBInstance> {
+  if (!instancePromise) {
     // On serverless (Vercel/Lambda) only /tmp is writable and HOME is empty,
     // so DuckDB can't find a home dir for its extensions (incl. MotherDuck).
-    // Point HOME at /tmp before connecting; DuckDB reads it via getenv.
     process.env.HOME ||= "/tmp";
-    // DUCKDB_PATH lets us point at a local .duckdb file for testing;
-    // defaults to MotherDuck in production.
+    // DUCKDB_PATH lets us point at a local .duckdb file for testing.
     const path = process.env.DUCKDB_PATH ?? "md:battlerap";
-    connPromise = DuckDBInstance.create(path).then((i) => i.connect());
+    instancePromise = DuckDBInstance.create(path);
   }
-  return connPromise;
+  return instancePromise;
 }
 
 // DuckDB returns BIGINT columns as JS `bigint`, which `JSON.stringify` throws
@@ -34,12 +31,20 @@ function toJson<T>(row: Record<string, DuckDBValue>): T {
 }
 
 export async function query<T>(sql: string, params: DuckDBValue[] = []): Promise<T[]> {
-  const conn = await connect();
-  const reader = await conn.runAndReadAll(sql, params);
-  return reader.getRowObjects().map((r) => toJson<T>(r));
+  const conn = await (await getInstance()).connect();
+  try {
+    const reader = await conn.runAndReadAll(sql, params);
+    return reader.getRowObjects().map((r) => toJson<T>(r));
+  } finally {
+    conn.closeSync();
+  }
 }
 
 export async function execute(sql: string, params: DuckDBValue[] = []): Promise<void> {
-  const conn = await connect();
-  await conn.run(sql, params);
+  const conn = await (await getInstance()).connect();
+  try {
+    await conn.run(sql, params);
+  } finally {
+    conn.closeSync();
+  }
 }


### PR DESCRIPTION
Two fixes:

1. **Re-land #21** — it never actually reached main (stacked-merge went sideways). Cherry-picked: sortable ranking columns, top-50 expand, nav reorder (Ranking left / About right), RankingTable client component.
2. **Fix the post-vote 500s** (`Failed to execute prepared statement`) — a single shared DuckDB connection can't run statements concurrently, so the vote write overlapping the next matchup read collided. Now: shared instance, one short-lived connection per operation. Verified with 12 parallel read+writes.