### PR TITLE
Pin background glow to viewport

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -18,6 +18,9 @@ body {
   background:
     radial-gradient(1100px 550px at 50% -12%, rgba(29, 185, 84, 0.14), transparent 60%),
     var(--background);
+  /* pin the glow to the viewport so it stays a top wash and doesn't drift
+     into the middle of long pages (e.g. the ranking table) */
+  background-attachment: fixed;
   color: var(--foreground);
   font-family: var(--font-inter), system-ui, sans-serif;
 }


### PR DESCRIPTION
The body radial glow used default scroll attachment + a `-12%` offset on the tall document, so it drifted into the middle of long pages (looked like a second green band around row #17 in the ranking). `background-attachment: fixed` keeps it a consistent top-of-viewport wash.

Top-3 podium tint is unchanged (intentional).