### PR TITLE
Ranking: monthly-listeners tiebreaker + shorter disclaimer

### DIFF
--- a/frontend/app/ranking/page.tsx
+++ b/frontend/app/ranking/page.tsx
@@ -9,10 +9,7 @@ export default async function RankingPage() {
   return (
     <section className="mx-auto max-w-4xl px-4 py-10">
       <h1 className="mb-2 text-3xl font-bold">Ranking</h1>
-      <p className="mb-6 text-sm text-white/50">
-        Only artists with at least 5 matchups are ranked, so a lone 1–0 doesn&apos;t
-        top the board at 100%.
-      </p>
+      <p className="mb-6 text-sm text-white/50">*minimum 5 matchups</p>
       <RankingTable rows={rows} />
     </section>
   );

--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -103,6 +103,6 @@ export async function getRanking(): Promise<RankingRow[]> {
      LEFT JOIN wins w USING (artist_id)
      LEFT JOIN losses l USING (artist_id)
      WHERE coalesce(w.wins, 0) + coalesce(l.losses, 0) >= 5
-     ORDER BY win_rate DESC, wins DESC`,
+     ORDER BY win_rate DESC, wins DESC, monthly_listeners DESC`,
   );
 }


### PR DESCRIPTION
- `ORDER BY win_rate DESC, wins DESC, monthly_listeners DESC` — breaks remaining ties by monthly listeners.
- Disclaimer shortened to `*minimum 5 matchups`.