### PR TITLE
Fix stale matchup roster: rappers_filtered full-refresh table

### DIFF
--- a/dbt/models/mart/rappers_filtered.sql
+++ b/dbt/models/mart/rappers_filtered.sql
@@ -1,10 +1,12 @@
 {{
     config(
-        materialized='incremental',
-        unique_key='artist_id'
+        materialized='table'
     )
 }}
 
+-- Current eligible set, rebuilt in FULL each run (not incremental) so artists
+-- that drop out -- genre-filtered at ingestion, fallen below the thresholds,
+-- or delisted -- actually disappear from matchups instead of lingering.
 -- popularity (0-100) is gone; filter on monthly_listeners instead.
 SELECT
     artist_id,
@@ -19,8 +21,3 @@ FROM {{ ref('rappers') }}
 WHERE flag_core_genre = TRUE
 AND monthly_listeners > 1000000
 AND followers > 100000
-
-{% if is_incremental() %}
-    -- coalesce so an empty table (max = NULL) loads everything, not nothing
-    AND load_date > (select coalesce(max(load_date), timestamp '1900-01-01') from {{ this }})
-{% endif %}


### PR DESCRIPTION
The frontend serves matchups from `mart.rappers_filtered`, which was `materialized='incremental'` (no deletes). So an artist filtered out upstream (e.g. Raphaela via the graph filter) **lingered in the served table** — the graph logic stopped her being *appended* to raw, but never *removed* her from what the app reads.

Switch `rappers_filtered` to a full-refresh **table** so it always mirrors the current raw set. Verified: builds as a BASE TABLE, tests pass.

Pairs with #28: #28 filters at ingestion, this makes the served roster actually reflect it. Run the pipeline after merge to purge lingering rows.