### PR TITLE
Genre filter: mutual relatedness, drop trust-playlist exemption

### DIFF
--- a/ingestion/artist_lister.py
+++ b/ingestion/artist_lister.py
@@ -28,9 +28,6 @@ class ArtistLister:
 
     def combine_artists(self, genre_dict, playlist_dict):
         """{artist_id: {"name": str, "seeds": set}} from searches + playlists."""
-        # playlist names are the trusted (hand-curated) seeds; keyword-genre
-        # searches are the noisy ones the graph filter should police.
-        self.trusted_seeds = set(playlist_dict.values())
         artists = defaultdict(lambda: {"name": None, "seeds": set()})
 
         for genre, limit in genre_dict.items():
@@ -53,13 +50,22 @@ class ArtistLister:
         """Fetch every artist once (parallel), then genre-filter -> rows.
 
         One network call per artist yields metadata, top tracks, and related
-        artists. Playlist-sourced artists are trusted outright (curated). For
-        the noisier keyword-search-sourced artists we use related artists as a
-        genre signal: rappers relate to rappers, so a search-sourced artist is
-        kept only if at least `min_related_in_pool` of their related artists
-        also showed up in the pool. This drops keyword false positives (e.g. a
-        sertanejo singer whose *name* contains "rap") without touching curated
-        playlist artists.
+        artists. Relatedness is the genre signal (rappers relate to rappers),
+        and we check it BOTH directions against the discovered pool:
+
+          * outward -- the artist relates to >= `min_related_in_pool` pool
+            members, or
+          * inward  -- >= 1 pool member relates back to the artist.
+
+        An artist is kept if EITHER holds. Inward rescues real rappers whose
+        own peers aren't in the pool yet (e.g. Young Dro, Atmosphere) but whom
+        pool rappers still cite. Requiring both signals to be zero to drop
+        catches off-genre artists disconnected from the rap graph entirely:
+        keyword false positives (a sertanejo singer whose *name* has "rap")
+        AND non-rap guests Spotify lists on a curated rap playlist (Peter
+        Gabriel, one Alt-Hip-Hop track, related artists all classic rock).
+        A pure outward+pool check alone would wrongly drop Young Dro/Atmosphere;
+        a 2-hop union would wrongly keep Peter Gabriel -- inward is the split.
         """
 
         def work(aid):
@@ -76,17 +82,21 @@ class ArtistLister:
                     enriched[aid] = res
 
         pool = set(enriched)
-        trusted = getattr(self, "trusted_seeds", set())
+        # inward vouches: how many pool artists relate TO each id
+        in_degree = defaultdict(int)
+        for res in enriched.values():
+            for rid in res["related"]:
+                in_degree[rid] += 1
+
         rapper_rows, track_rows, dropped = [], [], []
         for aid, res in enriched.items():
             seeds = artist_dict[aid]["seeds"]
-            # trust playlist-sourced artists (curated); only graph-filter the
-            # keyword-search-sourced ones, where the fuzzy noise comes from.
-            if not (seeds & trusted):
-                overlap = sum(1 for rid in res["related"] if rid in pool)
-                if overlap < min_related_in_pool:
-                    dropped.append(res["artist"]["artist_name"])
-                    continue
+            # keep if the rap graph connects to the artist in EITHER direction
+            outward = sum(1 for rid in res["related"] if rid in pool)
+            inward = in_degree.get(aid, 0)
+            if outward < min_related_in_pool and inward < 1:
+                dropped.append(res["artist"]["artist_name"])
+                continue
             rapper_rows.append(
                 {
                     **res["artist"],


### PR DESCRIPTION
## Problem
Peter Gabriel showed up in matchups despite the genre filter. Root cause: **#28's trust-playlist exemption** — playlist-sourced artists skipped the graph filter entirely. Spotify lists Peter Gabriel as a *featured guest* on one track ("Beyond The Brilliant Haze", w/ rapper IDK) on the curated **Alternative Hip-Hop** playlist, so he was trusted in unfiltered. His related artists are 100% classic rock (Genesis, Yes, Talk Talk) — zero rap peers.

## Fix
Drop the exemption; graph-filter **every** artist. But a naive outward-only check re-drops real rappers whose peers aren't in our pool yet (Young Dro, Atmosphere). So check relatedness in **both directions**:
- **outward** — artist relates to ≥1 pool member, OR
- **inward** — ≥1 pool member relates back (in-degree ≥ 1)

Keep if either holds. Inward rescues Young Dro/Atmosphere (pool rappers cite them); both-zero drops the graph-disconnected off-genre artists.

Considered and rejected a 2-hop union (pool ∪ pool's-related) — too lenient, re-admitted Peter Gabriel, Raphaela Santos, *and* Reneé Rapp via leftfield bridges. In-degree is the clean split. No extra network calls (built from already-fetched related lists).

## Validation (live enrich, 547-artist pool)
| Artist | Result |
|---|---|
| Peter Gabriel | DROPPED ✓ |
| Raphaela Santos, Reneé Rapp | DROPPED ✓ |
| Young Dro, Atmosphere | KEPT ✓ |
| NF, IDK, Kendrick, Drake, J. Cole, Doja Cat, Freddie Gibbs | KEPT ✓ |

114 dropped, 433 kept.

## After merge
Re-run the **refresh-rappers** Action to rebuild `raw.rappers` + `rappers_filtered` (full-refresh table) so Peter Gabriel drops out of live matchups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)