### PR TITLE
Replace Spotify iframe track embeds with native track cards

### DIFF
--- a/frontend/components/BracketArena.tsx
+++ b/frontend/components/BracketArena.tsx
@@ -265,7 +265,7 @@ export function BracketArena({
       <p className="mb-6 text-center text-sm uppercase tracking-widest text-white/50">
         {roundLabel(remainingMatches)} · #{currentMatch.a.seed} vs #{currentMatch.b.seed}
       </p>
-      <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-4 sm:gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-start gap-4 sm:gap-6">
         <RapperCard
           rapper={{
             ...currentMatch.a,

--- a/frontend/components/RapperCard.tsx
+++ b/frontend/components/RapperCard.tsx
@@ -27,7 +27,7 @@ function TrackRow({ track }: { track: Track }) {
     <div
       onMouseEnter={start}
       onMouseLeave={stop}
-      className={`flex items-center gap-3 rounded-xl border p-2 transition duration-200 ${
+      className={`flex min-w-0 items-center gap-3 rounded-xl border p-2 transition duration-200 ${
         isPlaying ? "border-accent/60" : "border-transparent"
       }`}
       style={track.tint_color ? { backgroundColor: track.tint_color } : undefined}
@@ -81,7 +81,7 @@ export function RapperCard({
 
   return (
     <div
-      className={`flex flex-col gap-3 transition duration-300 ${dimmed ? "opacity-40" : "opacity-100"}`}
+      className={`flex min-w-0 flex-col gap-3 transition duration-300 ${dimmed ? "opacity-40" : "opacity-100"}`}
     >
       {rapper.preview_url && <audio ref={audioRef} src={rapper.preview_url} preload="none" />}
       <button
@@ -126,7 +126,7 @@ export function RapperCard({
         )}
       </button>
 
-      <div className="flex flex-col gap-2">
+      <div className="flex min-w-0 flex-col gap-2">
         {tracks.map((t) => (
           <TrackRow key={t.track_id} track={t} />
         ))}

--- a/frontend/components/RapperCard.tsx
+++ b/frontend/components/RapperCard.tsx
@@ -1,77 +1,62 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import type { Rapper, Track } from "@/lib/types";
-import {
-  audioBus,
-  getSpotifyIframeApi,
-  type Pausable,
-  type SpotifyController,
-} from "@/lib/spotifyEmbed";
+import { useHoverPreview } from "@/lib/useHoverPreview";
 
 const compact = new Intl.NumberFormat("en-US", {
   notation: "compact",
   maximumFractionDigits: 1,
 });
 
-// Spotify track embed via the iFrame API, so its playback can be paused
-// programmatically and coordinated through the audio bus.
-export function TrackEmbed({
-  trackId,
-  title,
-  index,
-}: {
-  trackId: string;
-  title: string;
-  index: number;
-}) {
-  const hostRef = useRef<HTMLDivElement>(null);
+function formatDuration(ms: number | null): string {
+  if (ms == null) return "";
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${sec.toString().padStart(2, "0")}`;
+}
 
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-
-    // createController REPLACES the element it's given with an iframe. If we
-    // hand it the React-rendered node, React later can't find that node to
-    // unmount it (removeChild throws -> the page's error boundary). So mount
-    // into a throwaway child we own; React only ever removes `host`.
-    const mount = document.createElement("div");
-    host.appendChild(mount);
-
-    let controller: SpotifyController | undefined;
-    let cancelled = false;
-
-    // Stagger creation: firing every embed's controller at once trips
-    // Spotify's embed throttle ("upstream request timeout"). Space them out.
-    const timer = setTimeout(() => {
-      getSpotifyIframeApi().then((API) => {
-        if (cancelled) return;
-        API.createController(
-          mount,
-          { uri: `spotify:track:${trackId}`, width: "100%", height: 80 },
-          (ctrl) => {
-            controller = ctrl;
-            const handle: Pausable = { pause: () => ctrl.pause() };
-            ctrl.addListener("playback_update", (e) => {
-              if (!e.data.isPaused) audioBus.claim(handle);
-              else audioBus.release(handle);
-            });
-          },
-        );
-      });
-    }, index * 450);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-      try {
-        controller?.destroy();
-      } catch {}
-    };
-  }, [trackId, index]);
+// Native replacement for a Spotify <iframe> embed -- hover to play the
+// track's own 30s preview clip (same audioBus-coordinated fade as the artist
+// card image), styled after Spotify's own embed using the metadata scraped
+// alongside the preview URL (art, duration, explicit flag, credit, tint).
+function TrackRow({ track }: { track: Track }) {
+  const { audioRef, isPlaying, start, stop } = useHoverPreview(track.preview_url);
 
   return (
-    <div ref={hostRef} title={title} className="min-h-20 w-full overflow-hidden rounded-xl" />
+    <div
+      onMouseEnter={start}
+      onMouseLeave={stop}
+      className={`flex items-center gap-3 rounded-xl border p-2 transition duration-200 ${
+        isPlaying ? "border-accent/60" : "border-transparent"
+      }`}
+      style={track.tint_color ? { backgroundColor: track.tint_color } : undefined}
+    >
+      {track.preview_url && <audio ref={audioRef} src={track.preview_url} preload="none" />}
+      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-md bg-white/10">
+        {track.image_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={track.image_url} alt="" className="h-full w-full object-cover" />
+        )}
+        {isPlaying && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-sm">
+            ▶
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <p className="truncate text-sm font-semibold">{track.track_name}</p>
+          {track.is_explicit && (
+            <span className="shrink-0 rounded bg-white/15 px-1 text-[10px] font-bold leading-tight">
+              E
+            </span>
+          )}
+        </div>
+        {track.credit && <p className="truncate text-xs text-white/60">{track.credit}</p>}
+      </div>
+      <span className="shrink-0 text-xs text-white/60">{formatDuration(track.duration_ms)}</span>
+    </div>
   );
 }
 
@@ -92,85 +77,18 @@ export function RapperCard({
   onPick: () => void;
   autoplay?: boolean;
 }) {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const fadeRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const busHandle = useRef<Pausable>({ pause: () => {} });
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const fadeTo = useCallback((target: number, onDone?: () => void) => {
-    const el = audioRef.current;
-    if (!el) return;
-    if (fadeRef.current) clearInterval(fadeRef.current);
-    fadeRef.current = setInterval(() => {
-      const step = 0.08;
-      if (Math.abs(el.volume - target) <= step) {
-        el.volume = target;
-        if (fadeRef.current) clearInterval(fadeRef.current);
-        onDone?.();
-      } else {
-        el.volume += el.volume < target ? step : -step;
-      }
-    }, 40);
-  }, []);
-
-  const stopPreview = useCallback(() => {
-    const el = audioRef.current;
-    if (!el) return;
-    audioBus.release(busHandle.current);
-    setIsPlaying(false);
-    fadeTo(0, () => el.pause());
-  }, [fadeTo]);
-
-  const startPreview = useCallback(() => {
-    const el = audioRef.current;
-    if (!el || !rapper.preview_url) return;
-    audioBus.claim(busHandle.current); // pause any playing track/clip first
-    el.currentTime = 0;
-    el.volume = 0;
-    el
-      .play()
-      .then(() => {
-        setIsPlaying(true);
-        fadeTo(0.85);
-      })
-      .catch(() => {}); // ignore autoplay blocks
-  }, [rapper.preview_url, fadeTo]);
-
-  // the bus pauses the hover clip by calling this handle
-  useEffect(() => {
-    busHandle.current.pause = stopPreview;
-  }, [stopPreview]);
-
-  // e.g. the bracket champion screen -- plays without waiting for a hover.
-  // Relies on the "sticky" user-activation the page already has from the
-  // click that got here, so browsers don't block the programmatic play().
-  useEffect(() => {
-    if (!autoplay) return;
-    startPreview();
-    return stopPreview;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoplay, rapper.artist_id]);
-
-  useEffect(
-    () => () => {
-      if (fadeRef.current) clearInterval(fadeRef.current);
-      audioRef.current?.pause();
-    },
-    [],
-  );
+  const { audioRef, isPlaying, start, stop } = useHoverPreview(rapper.preview_url, autoplay);
 
   return (
     <div
       className={`flex flex-col gap-3 transition duration-300 ${dimmed ? "opacity-40" : "opacity-100"}`}
     >
-      {rapper.preview_url && (
-        <audio ref={audioRef} src={rapper.preview_url} preload="none" />
-      )}
+      {rapper.preview_url && <audio ref={audioRef} src={rapper.preview_url} preload="none" />}
       <button
         type="button"
         onClick={onPick}
-        onMouseEnter={startPreview}
-        onMouseLeave={stopPreview}
+        onMouseEnter={start}
+        onMouseLeave={stop}
         disabled={disabled}
         className={`group relative aspect-square w-full overflow-hidden rounded-2xl border-2 transition duration-200
           ${picked ? "border-accent shadow-[0_0_40px_-8px_var(--accent)]" : "border-white/10"}
@@ -209,13 +127,8 @@ export function RapperCard({
       </button>
 
       <div className="flex flex-col gap-2">
-        {tracks.map((t, i) => (
-          <TrackEmbed
-            key={t.track_id}
-            trackId={t.track_id}
-            title={t.track_name}
-            index={i}
-          />
+        {tracks.map((t) => (
+          <TrackRow key={t.track_id} track={t} />
         ))}
       </div>
     </div>

--- a/frontend/components/VoteArena.tsx
+++ b/frontend/components/VoteArena.tsx
@@ -53,7 +53,7 @@ export function VoteArena({ initial }: { initial: Matchup }) {
 
   return (
     <section className="mx-auto max-w-5xl px-4 py-8">
-      <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-4 sm:gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-start gap-4 sm:gap-6">
         <RapperCard
           rapper={rapper1}
           tracks={tracks1}

--- a/frontend/lib/data.ts
+++ b/frontend/lib/data.ts
@@ -10,13 +10,20 @@ async function eligibleRappers(): Promise<Rapper[]> {
   );
 }
 
-// Fetch 5 so the preview clip has variety to pick from; only the top 3 are
-// ever shown as embeds (sliced in pairTracks below).
+// A 64-artist bracket runs 6 rounds, so a champion needs up to 6 distinct
+// hover-preview picks -- POOL_SIZE has to comfortably clear that (with a
+// couple spare so even the last round or two still has a real choice).
+// VISIBLE_COUNT is how many of those are rendered as TrackRow cards; native
+// rows are cheap (no iframe), so this can run higher than the old Spotify
+// embed's 3 without a real performance cost.
+const POOL_SIZE = 8;
+const VISIBLE_COUNT = 5;
+
 async function topTracks(artistId: string): Promise<Track[]> {
   return query<Track>(
     `SELECT track_id, artist_id, track_name, track_rank, track_url
      FROM mart.top_tracks
-     WHERE artist_id = ? AND track_rank <= 5
+     WHERE artist_id = ? AND track_rank <= ${POOL_SIZE}
      ORDER BY track_rank`,
     [artistId],
   );
@@ -24,8 +31,8 @@ async function topTracks(artistId: string): Promise<Track[]> {
 
 // excludeIds lets a caller avoid repeating a preview clip already played
 // (e.g. the same artist advancing through multiple bracket rounds) -- if
-// every track's been excluded already (all 5 seen), fall back to the full
-// pool rather than picking nothing.
+// every track's been excluded already (all POOL_SIZE seen), fall back to the
+// full pool rather than picking nothing.
 function randomTrack(tracks: Track[], excludeIds: string[] = []): Track | undefined {
   const pool = excludeIds.length > 0 ? tracks.filter((t) => !excludeIds.includes(t.track_id)) : tracks;
   const candidates = pool.length > 0 ? pool : tracks;
@@ -33,11 +40,12 @@ function randomTrack(tracks: Track[], excludeIds: string[] = []): Track | undefi
   return candidates[Math.floor(Math.random() * candidates.length)];
 }
 
-// Top 3 tracks (for the visible embeds) + a hover-preview clip randomly
-// picked from the top 5 (so it's not the same snippet every single time) for
-// a specific pair of artists -- used for both the random head-to-head
-// matchup and a single bracket match. exclude1/exclude2 are track ids
-// already played for that artist earlier in the same run (bracket mode only).
+// Top VISIBLE_COUNT tracks (rendered as native TrackRow cards, not Spotify
+// iframes) + a hover-preview clip randomly picked from the full POOL_SIZE
+// pool (so it's not the same snippet every single time) for a specific pair
+// of artists -- used for both the random head-to-head matchup and a single
+// bracket match. exclude1/2 are track ids already played for that artist
+// earlier in the same run (bracket mode only).
 export async function pairTracks(
   id1: string,
   id2: string,
@@ -55,17 +63,23 @@ export async function pairTracks(
 }> {
   const [top1, top2] = await Promise.all([topTracks(id1), topTracks(id2)]);
   const [pick1, pick2] = [randomTrack(top1, exclude1), randomTrack(top2, exclude2)];
-  const [preview1, preview2] = await Promise.all([
-    topPreviewUrl(pick1?.track_id),
-    topPreviewUrl(pick2?.track_id),
+  const visible1 = top1.slice(0, VISIBLE_COUNT);
+  const visible2 = top2.slice(0, VISIBLE_COUNT);
+
+  const [meta1, meta2, pickMeta1, pickMeta2] = await Promise.all([
+    Promise.all(visible1.map((t) => scrapeTrackMeta(t.track_id))),
+    Promise.all(visible2.map((t) => scrapeTrackMeta(t.track_id))),
+    scrapeTrackMeta(pick1?.track_id),
+    scrapeTrackMeta(pick2?.track_id),
   ]);
+
   return {
-    tracks1: top1.slice(0, 3),
-    preview1,
+    tracks1: visible1.map((t, i) => ({ ...t, ...meta1[i] })),
+    preview1: pickMeta1.preview_url,
     previewTrackId1: pick1?.track_id ?? null,
     previewTrackName1: pick1?.track_name ?? null,
-    tracks2: top2.slice(0, 3),
-    preview2,
+    tracks2: visible2.map((t, i) => ({ ...t, ...meta2[i] })),
+    preview2: pickMeta2.preview_url,
     previewTrackId2: pick2?.track_id ?? null,
     previewTrackName2: pick2?.track_name ?? null,
   };
@@ -96,24 +110,82 @@ export async function getMatchup(): Promise<Matchup> {
   };
 }
 
-// The 30s preview MP3 isn't exposed by the API anymore; scrape it from the
-// track's embed page (same __NEXT_DATA__ trick as the playlist reader).
-async function topPreviewUrl(trackId?: string): Promise<string | null> {
-  if (!trackId) return null;
-  try {
-    const res = await fetch(`https://open.spotify.com/embed/track/${trackId}`, {
-      headers: { "User-Agent": "Mozilla/5.0" },
-    });
-    const html = await res.text();
-    const m = html.match(
-      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
-    );
-    if (!m) return null;
-    const data = JSON.parse(m[1]);
-    return data?.props?.pageProps?.state?.data?.entity?.audioPreview?.url ?? null;
-  } catch {
-    return null;
-  }
+type TrackMeta = {
+  preview_url: string | null;
+  duration_ms: number | null;
+  image_url: string | null;
+  is_explicit: boolean;
+  credit: string | null;
+  tint_color: string | null;
+};
+
+const EMPTY_TRACK_META: TrackMeta = {
+  preview_url: null,
+  duration_ms: null,
+  image_url: null,
+  is_explicit: false,
+  credit: null,
+  tint_color: null,
+};
+
+// Same top tracks get re-scraped every round an artist advances in a bracket
+// (the visible tracks don't change, only the randomized preview pick does),
+// and Spotify's embed endpoint throttles (429s) under repeated requests --
+// so cache successful scrapes for the life of this server instance. Failed/
+// throttled results are NOT cached, so a later call can retry once whatever
+// caused the miss clears.
+const trackMetaCache = new Map<string, Promise<TrackMeta>>();
+
+// The 30s preview MP3 isn't exposed by the API anymore; scrape it (plus art,
+// duration, explicit flag, credit and Spotify's own background tint for the
+// track) from the track's embed page's __NEXT_DATA__ payload -- this is what
+// lets tracks render as native cards instead of a Spotify <iframe> embed.
+async function scrapeTrackMeta(trackId?: string): Promise<TrackMeta> {
+  if (!trackId) return EMPTY_TRACK_META;
+
+  const cached = trackMetaCache.get(trackId);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<TrackMeta> => {
+    try {
+      const res = await fetch(`https://open.spotify.com/embed/track/${trackId}`, {
+        headers: { "User-Agent": "Mozilla/5.0" },
+      });
+      const html = await res.text();
+      const m = html.match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
+      if (!m) return EMPTY_TRACK_META;
+      const entity = JSON.parse(m[1])?.props?.pageProps?.state?.data?.entity;
+      if (!entity) return EMPTY_TRACK_META;
+
+      const images = entity.visualIdentity?.image as
+        | { url: string; maxWidth: number }[]
+        | undefined;
+      const image = images?.slice().sort((a, b) => b.maxWidth - a.maxWidth)[0];
+      const tint = entity.visualIdentity?.backgroundTintedBase as
+        | { red: number; green: number; blue: number }
+        | undefined;
+      const artists = entity.artists as { name: string }[] | undefined;
+
+      return {
+        preview_url: entity.audioPreview?.url ?? null,
+        duration_ms: entity.duration ?? null,
+        image_url: image?.url ?? null,
+        is_explicit: entity.isExplicit ?? false,
+        credit: artists && artists.length > 0 ? artists.map((a) => a.name).join(", ") : null,
+        tint_color: tint ? `rgb(${tint.red}, ${tint.green}, ${tint.blue})` : null,
+      };
+    } catch {
+      return EMPTY_TRACK_META;
+    }
+  })().then((meta) => {
+    if (!meta.preview_url) trackMetaCache.delete(trackId);
+    return meta;
+  });
+
+  trackMetaCache.set(trackId, promise);
+  return promise;
 }
 
 export async function recordVote(winnerId: string, loserId: string): Promise<void> {

--- a/frontend/lib/spotifyEmbed.ts
+++ b/frontend/lib/spotifyEmbed.ts
@@ -1,9 +1,5 @@
-// Spotify iFrame API loader + a tiny "one sound at a time" coordinator.
-//
-// Plain <iframe> embeds are cross-origin black boxes — you can't pause them or
-// know they're playing. The iFrame API hands back a *controller* per track with
-// play/pause + playback events, so we can enforce a single active sound across
-// all track embeds AND the hover preview clip.
+// A tiny "one sound at a time" coordinator shared by the artist card's hover
+// preview and every track row's own preview clip.
 
 export type Pausable = { pause: () => void };
 
@@ -19,42 +15,3 @@ export const audioBus = {
     if (current === source) current = null;
   },
 };
-
-export type SpotifyController = {
-  play: () => void;
-  pause: () => void;
-  destroy: () => void;
-  addListener: (
-    event: string,
-    cb: (e: { data: { isPaused: boolean } }) => void,
-  ) => void;
-};
-
-export type SpotifyIframeApi = {
-  createController: (
-    el: HTMLElement,
-    opts: { uri: string; width: string | number; height: string | number },
-    cb: (controller: SpotifyController) => void,
-  ) => void;
-};
-
-declare global {
-  interface Window {
-    onSpotifyIframeApiReady?: (api: SpotifyIframeApi) => void;
-  }
-}
-
-let apiPromise: Promise<SpotifyIframeApi> | null = null;
-
-// load the API script once; resolves with the IFrameAPI handle
-export function getSpotifyIframeApi(): Promise<SpotifyIframeApi> {
-  if (apiPromise) return apiPromise;
-  apiPromise = new Promise((resolve) => {
-    window.onSpotifyIframeApiReady = (api) => resolve(api);
-    const script = document.createElement("script");
-    script.src = "https://open.spotify.com/embed/iframe-api/v1";
-    script.async = true;
-    document.body.appendChild(script);
-  });
-  return apiPromise;
-}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -15,6 +15,14 @@ export type Track = {
   track_name: string;
   track_rank: number;
   track_url: string;
+  // Scraped from Spotify's embed page (see lib/data.ts scrapeTrackMeta) so the
+  // track row can be rendered natively instead of via a Spotify <iframe>.
+  preview_url: string | null;
+  duration_ms: number | null;
+  image_url: string | null;
+  is_explicit: boolean;
+  credit: string | null; // featured-artist credit line, e.g. "Metro Boomin, Travis Scott"
+  tint_color: string | null; // Spotify's embed background tint, e.g. "rgb(8, 32, 64)"
 };
 
 export type Matchup = {

--- a/frontend/lib/useHoverPreview.ts
+++ b/frontend/lib/useHoverPreview.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { audioBus, type Pausable } from "./spotifyEmbed";
+
+// Fades a 30s preview clip in on hover (or on demand via `autoplay`) and back
+// out on mouse-leave, claiming the shared audioBus so only one clip plays at
+// once across the whole page -- used by both the artist card's image and
+// each track row.
+export function useHoverPreview(url: string | null, autoplay = false) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const fadeRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const busHandle = useRef<Pausable>({ pause: () => {} });
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const fadeTo = useCallback((target: number, onDone?: () => void) => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (fadeRef.current) clearInterval(fadeRef.current);
+    fadeRef.current = setInterval(() => {
+      const step = 0.08;
+      if (Math.abs(el.volume - target) <= step) {
+        el.volume = target;
+        if (fadeRef.current) clearInterval(fadeRef.current);
+        onDone?.();
+      } else {
+        el.volume += el.volume < target ? step : -step;
+      }
+    }, 40);
+  }, []);
+
+  const stop = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    audioBus.release(busHandle.current);
+    setIsPlaying(false);
+    fadeTo(0, () => el.pause());
+  }, [fadeTo]);
+
+  const start = useCallback(() => {
+    const el = audioRef.current;
+    if (!el || !url) return;
+    audioBus.claim(busHandle.current); // pause any playing track/clip first
+    el.currentTime = 0;
+    el.volume = 0;
+    el
+      .play()
+      .then(() => {
+        setIsPlaying(true);
+        fadeTo(0.85);
+      })
+      .catch(() => {}); // ignore autoplay blocks
+  }, [url, fadeTo]);
+
+  // the bus pauses this clip by calling this handle
+  useEffect(() => {
+    busHandle.current.pause = stop;
+  }, [stop]);
+
+  // e.g. the bracket champion screen -- plays without waiting for a hover.
+  // Relies on the "sticky" user-activation the page already has from the
+  // click that got here, so browsers don't block the programmatic play().
+  useEffect(() => {
+    if (!autoplay) return;
+    start();
+    return stop;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoplay, url]);
+
+  useEffect(
+    () => () => {
+      if (fadeRef.current) clearInterval(fadeRef.current);
+      audioRef.current?.pause();
+    },
+    [],
+  );
+
+  return { audioRef, isPlaying, start, stop };
+}


### PR DESCRIPTION
## Summary
- Ditches the per-track Spotify `<iframe>` embed (staggered 450ms apart to dodge Spotify's embed throttle) in favor of a native `TrackRow`: album art, track name, explicit tag, duration, credit line, and Spotify's own background tint, all pulled from the same embed-page scrape already used for the hover-preview clip.
- Hover-to-play reuses the exact `audioBus`/fade pattern the artist card image already had, now extracted into a shared `useHoverPreview` hook (was duplicated logic, now one place).
- Bumps the hover-preview randomization pool from 5 to 8 tracks (a 64-artist bracket champion needs up to 6 distinct picks across rounds) and the visible rows from 3 to 5 (native rows are cheap, unlike the iframe).
- Adds an in-memory cache for successful track scrapes -- a bracket run re-scrapes the same artist's top tracks every round they advance, and testing this surfaced real Spotify 429s under repeated load. Failed/throttled scrapes aren't cached, so a later call can retry.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Manually verified against a local scratch DuckDB (throwaway `mart.*` views over the local raw tables) with Playwright: head-to-head page renders 5 real track rows (art/duration/credit/tint) per artist, hover-to-play works with no console errors, bracket mode plays through to a champion with tracks/preview/no-repeat/stats all intact
- [x] Confirmed graceful degradation to a plain row (no art/tint) when Spotify's scrape 429s, rather than crashing
- [ ] Validate on Vercel's preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)