### PR TITLE
Survive partial Spotify failures; add SQLFluff + SQL lint CI

### DIFF
--- a/.github/workflows/refresh-rappers.yml
+++ b/.github/workflows/refresh-rappers.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           enable-cache: true
 
-      # installs the exact locked deps (and provisions Python per requires-python)
-      - run: uv sync --frozen
+      # installs the exact locked deps (and provisions Python per requires-python).
+      # --no-dev skips sqlfluff and friends; the daily pipeline never lints.
+      - run: uv sync --frozen --no-dev
 
       - name: Ingest Spotify → MotherDuck
         run: uv run python -m ingestion.load_rappers

--- a/.github/workflows/sql-lint.yml
+++ b/.github/workflows/sql-lint.yml
@@ -1,0 +1,41 @@
+name: SQL lint (SQLFluff)
+
+# Lint only -- never `sqlfluff fix` in CI. A bot rewriting SQL on a branch races
+# your own pushes and turns a style nit into a merge conflict; the fix belongs on
+# the machine that wrote the query: `uv run sqlfluff fix dbt`.
+on:
+  pull_request:
+    paths:
+      - "dbt/**"
+      - ".sqlfluff"
+      - ".sqlfluffignore"
+      - ".github/workflows/sql-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "dbt/**"
+      - ".sqlfluff"
+      - ".sqlfluffignore"
+      - ".github/workflows/sql-lint.yml"
+  workflow_dispatch:
+
+jobs:
+  sqlfluff:
+    runs-on: ubuntu-latest
+    env:
+      # SQLFluff uses the dbt templater, so it compiles the project -- point that
+      # at a scratch DuckDB file so linting never touches MotherDuck and needs no
+      # token. Compilation doesn't read any data.
+      DBT_DUCKDB_PATH: /tmp/sqlfluff-lint.duckdb
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # dev group carries sqlfluff + sqlfluff-templater-dbt
+      - run: uv sync --frozen
+
+      - name: sqlfluff lint
+        run: uv run sqlfluff lint dbt

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,80 @@
+[sqlfluff]
+# Same ruleset as the bi-* Pulumi/BigQuery repos, with two changes for this project:
+#   * dialect duckdb (MotherDuck is cloud DuckDB), not bigquery
+#   * templater dbt, not jinja -- ref()/source()/config(), the elo macros and the
+#     {% snapshot %} block only resolve through dbt; plain jinja can't parse them.
+#     Linting compiles the project, so point DBT_DUCKDB_PATH at a throwaway file
+#     to keep sqlfluff off MotherDuck (no token needed).
+dialect = duckdb
+templater = dbt
+max_line_length = 160
+large_file_skip_byte_limit = 0
+# the recursive-CTE Elo models nest past the stock 255-level parse limit, which
+# is a DoS guard rather than a style rule -- raise it instead of exempting the
+# most complex SQL in the project from linting
+max_parse_depth = 2000
+recursion_limit = 5000
+indent_unit = space
+exclude_rules = ambiguous.column_count, structure.column_order, references.from
+
+[sqlfluff:templater:dbt]
+project_dir = dbt
+profiles_dir = dbt
+profile = default
+target = prod
+
+[sqlfluff:indentation]
+tab_space_size = 4
+indented_using_on = True
+allow_implicit_indents = True
+indented_on_contents = False
+template_blocks_indent = False
+
+[sqlfluff:layout:type:comma]
+spacing_before = touch
+line_position = trailing
+
+[sqlfluff:rules:references.special_chars]
+additional_allowed_characters = "{}"
+
+[sqlfluff:rules:aliasing.table]
+aliasing = explicit
+
+[sqlfluff:rules:aliasing.column]
+aliasing = explicit
+
+[sqlfluff:rules:aliasing.length]
+min_alias_length = 3
+
+[sqlfluff:rules:aliasing.expression]
+allow_scalar = False
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:convention.not_equal]
+preferred_not_equal_style = c_style
+
+# 1. Target the elements inside the FROM/JOIN specifically
+[sqlfluff:layout:type:from_expression_element]
+spacing_before = single:inline
+
+# 2. Target the alias specifically
+[sqlfluff:layout:type:alias_expression]
+spacing_before = single:inline
+
+# 3. Explicitly allow newlines for WHERE/AND/OR logic
+[sqlfluff:layout:type:expression]
+line_position = leading

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,0 +1,6 @@
+# dbt build artifacts -- compiled copies of the models we already lint
+target/
+dbt/target/
+dbt/logs/
+dbt_packages/
+dbt/dbt_packages/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A project built to answer the quintessential question: who is the greatest rappe
 
 **Transform** — [dbt](https://www.getdbt.com/) (`dbt-duckdb`) builds staging → mart models, with tests and snapshots. Includes `mart.elo` — a blended Elo rating (casual head-to-head + bracket matches weighted higher) computed with a recursive CTE, since Elo is inherently sequential and can't be a flat aggregate.
 
-**Ingestion** — Python 3.12 + [`spotapi`](https://github.com/Aran404/SpotAPI) (Spotify's internal web endpoints — no API key, no Premium needed), seeded by hip-hop genres/playlists, one fetch per artist parallelized with a thread pool. Deps locked with [uv](https://docs.astral.sh/uv/).
+**Ingestion** — Python 3.12 + [`spotapi`](https://github.com/Aran404/SpotAPI) (Spotify's internal web endpoints — no API key, no Premium needed), seeded by hip-hop genres/playlists, one fetch per artist parallelized with a thread pool. Deps locked with [uv](https://docs.astral.sh/uv/). Scraping an unofficial endpoint means routine partial failures, so the `raw` tables are append-only snapshots: `stg_rappers` keeps each artist's last good observation and `mart.rappers_filtered` retires them only after 14 days unseen, instead of a single rate-limited run emptying the battle pool.
 
 **Orchestration** — [GitHub Actions](.github/workflows/refresh-rappers.yml) runs the daily ingest + `dbt build` on a cron.
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -1,15 +1,49 @@
-Welcome to your new dbt project!
+# dbt (dbt-duckdb → MotherDuck)
 
-### Using the starter project
+Builds `staging` → `mart` on top of the `raw` schema the Python ingestion writes.
 
-Try running the following commands:
-- dbt run
-- dbt test
+```bash
+# from this directory
+uv run dbt build --profiles-dir .                    # models + tests + snapshot
+uv run dbt build --profiles-dir . -s mart.elo+       # one model and everything after it
+uv run dbt docs generate --profiles-dir . && uv run dbt docs serve --profiles-dir .
+```
 
+Targets MotherDuck (`md:battlerap`) by default, auth from the `motherduck_token`
+env var. Point it at a local file to experiment without touching prod:
 
-### Resources:
-- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
-- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
-- Find [dbt events](https://events.getdbt.com) near you
-- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices
+```bash
+DBT_DUCKDB_PATH=/tmp/battlerap.duckdb uv run dbt build --profiles-dir .
+```
+
+## Linting
+
+SQLFluff runs from the repo root (config in `../.sqlfluff`, same ruleset as the
+`bi-*` BigQuery repos with `dialect = duckdb`):
+
+```bash
+cd .. && DBT_DUCKDB_PATH=/tmp/lint.duckdb uv run sqlfluff lint dbt   # CI runs this
+cd .. && DBT_DUCKDB_PATH=/tmp/lint.duckdb uv run sqlfluff fix dbt    # rewrite in place
+```
+
+It uses the **dbt templater**, so linting compiles the project — hence the
+throwaway `DBT_DUCKDB_PATH` (no MotherDuck token needed; compiling reads no data).
+Two consequences worth knowing:
+
+- Only the branch that *would build right now* gets linted. In `elo_daily.sql` the
+  `{% if is_incremental() %}` side is invisible to SQLFluff on a fresh database, so
+  keep both branches styled by hand.
+- `max_parse_depth` is raised in `.sqlfluff`; the recursive Elo CTEs nest past the
+  stock 255-level guard and would otherwise be reported as unparseable.
+
+## Things that will bite you
+
+- **`mart.elo_daily` caches formula output.** Change the K factors or
+  `macros/elo_update.sql` and existing checkpoints are stale without dbt noticing:
+  `uv run dbt run --full-refresh -s mart.elo_daily+ --profiles-dir .`
+- **`raw.rappers` / `raw.top_tracks` are append-only.** Staging collapses them to
+  each artist's latest snapshot; `mart.rappers_filtered` retires artists unseen for
+  14 days. A failed scrape no longer deletes anyone.
+- **`analyses/elo_full_replay.sql`** is the drift audit for that checkpointing.
+  It's an analysis, not a test, because it's the O(matches × artists) work the
+  checkpoints exist to avoid. Run it by hand after touching the Elo math.

--- a/dbt/analyses/elo_full_replay.sql
+++ b/dbt/analyses/elo_full_replay.sql
@@ -16,48 +16,55 @@
 -- Expected legitimate cause of drift: a match arriving with a voted_at older
 -- than the watermark. The staging models already drop those on their own
 -- watermark (see stg_results.sql), so this should stay empty in practice.
-WITH RECURSIVE matches AS (
+with recursive matches as (
     {{ elo_matches() }}
 ),
 
-ordered_matches AS (
-    SELECT
-        row_number() OVER (ORDER BY voted_at, winner_id, loser_id) AS match_number,
+ordered_matches as (
+    select
+        row_number() over (order by voted_at, winner_id, loser_id) as match_number,
         winner_id,
         loser_id,
         k_factor
-    FROM matches
+    from matches
 ),
 
-elo_state AS (
+elo_state as (
     -- match_number = 0: nobody's played yet
-    SELECT 0 AS match_number, map([]::VARCHAR[], []::DOUBLE[]) AS ratings
+    select
+        0 as match_number,
+        map([]::varchar [], []::double []) as ratings
 
-    UNION ALL
+    union all
 
-    SELECT
+    select
         nxt.match_number,
-        {{ elo_update('prev', 'nxt') }} AS ratings
-    FROM elo_state AS prev
-    JOIN ordered_matches AS nxt ON nxt.match_number = prev.match_number + 1
+        {{ elo_update('prev', 'nxt') }} as ratings
+    from elo_state as prev
+    inner join ordered_matches as nxt on nxt.match_number = prev.match_number + 1
 ),
 
-from_scratch AS (
-    SELECT e.key AS artist_id, e.value AS elo_rating
-    FROM elo_state, UNNEST(map_entries(ratings)) AS t(e)
-    WHERE match_number = (SELECT coalesce(max(match_number), 0) FROM ordered_matches)
+from_scratch as (
+    select
+        entry.key as artist_id,
+        entry.value as elo_rating
+    from elo_state, unnest(map_entries(elo_state.ratings)) as rating_entries (entry)
+    where elo_state.match_number = (
+            select coalesce(max(nxt.match_number), 0) as last_match_number
+            from ordered_matches as nxt
+        )
 )
 
-SELECT
-    coalesce(s.artist_id, i.artist_id) AS artist_id,
-    s.elo_rating AS full_replay_elo,
-    i.elo_rating AS incremental_elo,
-    i.elo_rating - s.elo_rating AS drift
-FROM from_scratch AS s
-FULL OUTER JOIN {{ ref('elo') }} AS i USING (artist_id)
+select
+    coalesce(replayed.artist_id, incr.artist_id) as artist_id,
+    replayed.elo_rating as full_replay_elo,
+    incr.elo_rating as incremental_elo,
+    incr.elo_rating - replayed.elo_rating as drift
+from from_scratch as replayed
+full outer join {{ ref('elo') }} as incr on replayed.artist_id = incr.artist_id
 -- float tolerance: the two take different code paths to the same arithmetic, so
 -- allow last-bit noise but nothing a rating would actually notice
-WHERE s.artist_id IS NULL
-    OR i.artist_id IS NULL
-    OR abs(i.elo_rating - s.elo_rating) > 1e-6
-ORDER BY abs(coalesce(i.elo_rating - s.elo_rating, 0)) DESC
+where replayed.artist_id is null
+    or incr.artist_id is null
+    or abs(incr.elo_rating - replayed.elo_rating) > 1e-6
+order by abs(coalesce(incr.elo_rating - replayed.elo_rating, 0)) desc

--- a/dbt/models/mart/bracket_ranking_live.sql
+++ b/dbt/models/mart/bracket_ranking_live.sql
@@ -11,58 +11,66 @@
 --
 -- No ORDER BY: an outer SELECT isn't guaranteed to preserve a view's internal
 -- ordering, so callers sort explicitly.
-WITH wins AS (
-    SELECT winner_id AS artist_id, count(*) AS wins
-    FROM {{ source('raw', 'bracket_results') }}
-    GROUP BY 1
+with wins as (
+    select
+        winner_id as artist_id,
+        count(*) as wins
+    from {{ source('raw', 'bracket_results') }}
+    group by 1
 ),
 
-losses AS (
-    SELECT loser_id AS artist_id, count(*) AS losses
-    FROM {{ source('raw', 'bracket_results') }}
-    GROUP BY 1
+losses as (
+    select
+        loser_id as artist_id,
+        count(*) as losses
+    from {{ source('raw', 'bracket_results') }}
+    group by 1
 ),
 
-championships AS (
-    SELECT winner_id AS artist_id, count(*) AS championships
-    FROM {{ source('raw', 'bracket_results') }}
-    WHERE matches_in_round = 1
-    GROUP BY 1
+championships as (
+    select
+        winner_id as artist_id,
+        count(*) as championships
+    from {{ source('raw', 'bracket_results') }}
+    where matches_in_round = 1
+    group by 1
 ),
 
-final_four_appearances AS (
-    SELECT artist_id, count(*) AS final_fours
-    FROM (
-        SELECT winner_id AS artist_id
-        FROM {{ source('raw', 'bracket_results') }}
-        WHERE matches_in_round = 2
+final_four_appearances as (
+    select
+        artist_id,
+        count(*) as final_fours
+    from (
+        select winner_id as artist_id
+        from {{ source('raw', 'bracket_results') }}
+        where matches_in_round = 2
 
-        UNION ALL
+        union all
 
-        SELECT loser_id AS artist_id
-        FROM {{ source('raw', 'bracket_results') }}
-        WHERE matches_in_round = 2
+        select loser_id as artist_id
+        from {{ source('raw', 'bracket_results') }}
+        where matches_in_round = 2
     )
-    GROUP BY 1
+    group by 1
 )
 
-SELECT
-    r.artist_id,
-    r.artist_name,
-    r.monthly_listeners,
-    r.image_url,
-    coalesce(c.championships, 0) AS championships,
-    coalesce(f.final_fours, 0) AS final_fours,
-    coalesce(w.wins, 0) AS wins,
-    coalesce(l.losses, 0) AS losses,
-    coalesce(w.wins, 0)::DOUBLE
-        / nullif(coalesce(w.wins, 0) + coalesce(l.losses, 0), 0) AS win_rate,
-    coalesce(e.elo_rating, 1500) AS elo_rating
-FROM {{ ref('rappers') }} AS r
-LEFT JOIN wins AS w USING (artist_id)
-LEFT JOIN losses AS l USING (artist_id)
-LEFT JOIN championships AS c USING (artist_id)
-LEFT JOIN final_four_appearances AS f USING (artist_id)
-LEFT JOIN {{ ref('elo') }} AS e USING (artist_id)
+select
+    rap.artist_id,
+    rap.artist_name,
+    rap.monthly_listeners,
+    rap.image_url,
+    coalesce(title_counts.championships, 0) as championships,
+    coalesce(final_four_counts.final_fours, 0) as final_fours,
+    coalesce(win_counts.wins, 0) as wins,
+    coalesce(loss_counts.losses, 0) as losses,
+    coalesce(win_counts.wins, 0)::double
+    / nullif(coalesce(win_counts.wins, 0) + coalesce(loss_counts.losses, 0), 0) as win_rate,
+    coalesce(elo_ratings.elo_rating, 1500) as elo_rating
+from {{ ref('rappers') }} as rap
+left join wins as win_counts on rap.artist_id = win_counts.artist_id
+left join losses as loss_counts on rap.artist_id = loss_counts.artist_id
+left join championships as title_counts on rap.artist_id = title_counts.artist_id
+left join final_four_appearances as final_four_counts on rap.artist_id = final_four_counts.artist_id
+left join {{ ref('elo') }} as elo_ratings on rap.artist_id = elo_ratings.artist_id
 -- must have actually played a bracket match
-WHERE coalesce(w.wins, 0) + coalesce(l.losses, 0) > 0
+where coalesce(win_counts.wins, 0) + coalesce(loss_counts.losses, 0) > 0

--- a/dbt/models/mart/elo.sql
+++ b/dbt/models/mart/elo.sql
@@ -15,76 +15,87 @@
 -- MAP to change two entries, so cost grew with *both* the match count and the
 -- roster, i.e. superlinearly in calendar time. Per-run cost is now
 -- O(today's matches * artists) and stays flat as history piles up.
-WITH RECURSIVE matches AS (
+with recursive matches as (
     {{ elo_matches() }}
 ),
 
-checkpoint_date AS (
+checkpoint_date as (
     -- coalesce so a missing/empty elo_daily replays from match #1 rather than
     -- producing nothing -- correct either way, just slower.
-    SELECT coalesce(max(as_of_date), DATE '1900-01-01') AS as_of_date
-    FROM {{ ref('elo_daily') }}
+    select coalesce(max(as_of_date), date '1900-01-01') as as_of_date
+    from {{ ref('elo_daily') }}
 ),
 
 -- Whatever elo_daily hasn't closed out yet: today, plus any earlier day that
 -- slipped through if a run was missed.
-new_matches AS (
-    SELECT
+new_matches as (
+    select
         -- winner_id/loser_id as a tiebreak just makes the order deterministic
         -- for same-timestamp votes -- it doesn't need to mean anything.
-        row_number() OVER (ORDER BY m.voted_at, m.winner_id, m.loser_id) AS match_number,
-        m.winner_id,
-        m.loser_id,
-        m.k_factor
-    FROM matches AS m, checkpoint_date AS c
-    WHERE cast(m.voted_at AS DATE) > c.as_of_date
+        row_number() over (order by mch.voted_at, mch.winner_id, mch.loser_id) as match_number,
+        mch.winner_id,
+        mch.loser_id,
+        mch.k_factor
+    from matches as mch, checkpoint_date as chk
+    where cast(mch.voted_at as date) > chk.as_of_date
 ),
 
-seed AS (
-    SELECT coalesce(
-        map_from_entries(list({'key': d.artist_id, 'value': d.elo_rating})),
-        map([]::VARCHAR[], []::DOUBLE[])
-    ) AS ratings
-    FROM {{ ref('elo_daily') }} AS d, checkpoint_date AS c
-    WHERE d.as_of_date = c.as_of_date
+seed as (
+    select
+        coalesce(
+            map_from_entries(list({ 'key': dly.artist_id, 'value': dly.elo_rating })),
+            map(cast([] as varchar []), cast([] as double []))
+        ) as ratings
+    from {{ ref('elo_daily') }} as dly, checkpoint_date as chk
+    where dly.as_of_date = chk.as_of_date
 ),
 
 -- Threading the whole ratings table through as a single MAP value keeps this at
 -- one row per match rather than one row per artist per match.
-elo_state AS (
-    SELECT 0 AS match_number, ratings FROM seed
+elo_state as (
+    select
+        0 as match_number,
+        ratings
+    from seed
 
-    UNION ALL
+    union all
 
-    SELECT
+    select
         nxt.match_number,
-        {{ elo_update('prev', 'nxt') }} AS ratings
-    FROM elo_state AS prev
-    JOIN new_matches AS nxt ON nxt.match_number = prev.match_number + 1
+        {{ elo_update('prev', 'nxt') }} as ratings
+    from elo_state as prev
+    inner join new_matches as nxt on nxt.match_number = prev.match_number + 1
 ),
 
-final_ratings AS (
-    SELECT e.key AS artist_id, e.value AS elo_rating
-    FROM elo_state, UNNEST(map_entries(ratings)) AS t(e)
+final_ratings as (
+    select
+        entry.key as artist_id,
+        entry.value as elo_rating
+    from elo_state, unnest(map_entries(elo_state.ratings)) as rating_entries (entry)
     -- No matches since the checkpoint (max = NULL) means the checkpoint itself
     -- is the answer -- that's match_number 0, the seed row.
-    WHERE match_number = (SELECT coalesce(max(match_number), 0) FROM new_matches)
+    where elo_state.match_number = (
+            select coalesce(max(nxt.match_number), 0) as last_match_number
+            from new_matches as nxt
+        )
 ),
 
 -- Flat aggregate over the full history, and cheap, so it isn't checkpointed.
-games_played AS (
-    SELECT artist_id, count(*) AS games_played
-    FROM (
-        SELECT winner_id AS artist_id FROM matches
-        UNION ALL
-        SELECT loser_id AS artist_id FROM matches
-    )
-    GROUP BY artist_id
+games_played as (
+    select
+        artist_id,
+        count(*) as games_played
+    from (
+        select winner_id as artist_id from matches
+        union all
+        select loser_id as artist_id from matches
+    ) as appearances
+    group by artist_id
 )
 
-SELECT
-    f.artist_id,
-    f.elo_rating,
-    g.games_played
-FROM final_ratings f
-JOIN games_played g USING (artist_id)
+select
+    fin.artist_id,
+    fin.elo_rating,
+    gms.games_played
+from final_ratings as fin
+inner join games_played as gms on fin.artist_id = gms.artist_id

--- a/dbt/models/mart/elo_daily.sql
+++ b/dbt/models/mart/elo_daily.sql
@@ -22,84 +22,94 @@
 -- factors here or the math in macros/elo_update.sql and every existing
 -- checkpoint becomes stale without dbt noticing. Rebuild explicitly:
 --     dbt run --full-refresh -s mart.elo_daily+
-WITH RECURSIVE matches AS (
+with recursive matches as (
     {{ elo_matches() }}
 ),
 
 -- Everything on or before this date is already checkpointed and immutable.
-watermark AS (
+watermark as (
     {% if is_incremental() %}
         -- coalesce so an empty table (max = NULL) replays everything, not nothing
-        SELECT coalesce(max(as_of_date), DATE '1900-01-01') AS as_of_date FROM {{ this }}
+        select coalesce(max(as_of_date), date '1900-01-01') as as_of_date from {{ this }}
     {% else %}
-        SELECT DATE '1900-01-01' AS as_of_date
+    select date '1900-01-01' as as_of_date
     {% endif %}
 ),
 
-new_matches AS (
-    SELECT
+new_matches as (
+    select
         -- winner_id/loser_id as a tiebreak just makes the order deterministic
         -- for same-timestamp votes -- it doesn't need to mean anything.
-        row_number() OVER (ORDER BY m.voted_at, m.winner_id, m.loser_id) AS match_number,
-        cast(m.voted_at AS DATE) AS match_date,
-        m.winner_id,
-        m.loser_id,
-        m.k_factor
-    FROM matches AS m, watermark AS w
-    WHERE cast(m.voted_at AS DATE) > w.as_of_date
+        row_number() over (order by mch.voted_at, mch.winner_id, mch.loser_id) as match_number,
+        cast(mch.voted_at as date) as match_date,
+        mch.winner_id,
+        mch.loser_id,
+        mch.k_factor
+    from matches as mch, watermark as wtm
+    where cast(mch.voted_at as date) > wtm.as_of_date
         -- Today can still receive votes, so freezing it now would drop every
         -- vote cast after this run: the next run's watermark would already be
         -- today, and `> watermark` would skip them forever. Checkpoint it
         -- tomorrow, once it can't change.
-        AND cast(m.voted_at AS DATE) < current_date
+        and cast(mch.voted_at as date) < current_date
 ),
 
-seed AS (
+seed as (
     {% if is_incremental() %}
         -- Resume from the last checkpoint instead of match #1. Aggregating with
         -- no GROUP BY still yields one row when the table is empty, so the
         -- coalesce turns "no checkpoint yet" into an empty map.
-        SELECT coalesce(
-            map_from_entries(list({'key': c.artist_id, 'value': c.elo_rating})),
-            map([]::VARCHAR[], []::DOUBLE[])
-        ) AS ratings
-        FROM {{ this }} AS c, watermark AS w
-        WHERE c.as_of_date = w.as_of_date
+        -- NB: sqlfluff only ever sees ONE side of this branch (the dbt templater
+        -- renders the model as it would build right now), so keep both hands
+        -- styled the same by eye -- the linter can't do it for you.
+        select coalesce(
+            map_from_entries(list({ 'key': ckp.artist_id, 'value': ckp.elo_rating })),
+            map(cast([] as varchar []), cast([] as double []))
+        ) as ratings
+        from {{ this }} as ckp, watermark as wtm
+        where ckp.as_of_date = wtm.as_of_date
     {% else %}
-        -- nobody's played yet
-        SELECT map([]::VARCHAR[], []::DOUBLE[]) AS ratings
+    -- nobody's played yet
+    select map(cast([] as varchar []), cast([] as double [])) as ratings
     {% endif %}
 ),
 
 -- Threading the whole ratings table through as a single MAP value keeps this at
 -- one row per match rather than one row per artist per match.
-elo_state AS (
-    SELECT 0 AS match_number, ratings FROM seed
+elo_state as (
+    select
+        0 as match_number,
+        ratings
+    from seed
 
-    UNION ALL
+    union all
 
-    SELECT
+    select
         nxt.match_number,
-        {{ elo_update('prev', 'nxt') }} AS ratings
-    FROM elo_state AS prev
-    JOIN new_matches AS nxt ON nxt.match_number = prev.match_number + 1
+        {{ elo_update('prev', 'nxt') }} as ratings
+    from elo_state as prev
+    inner join new_matches as nxt on nxt.match_number = prev.match_number + 1
 ),
 
 -- the state after a day's last match *is* that day's closing checkpoint
-day_ends AS (
-    SELECT match_date, max(match_number) AS match_number
-    FROM new_matches
-    GROUP BY match_date
+day_ends as (
+    select
+        match_date,
+        max(match_number) as match_number
+    from new_matches
+    group by match_date
 ),
 
-day_end_state AS (
-    SELECT d.match_date, s.ratings
-    FROM day_ends AS d
-    JOIN elo_state AS s USING (match_number)
+day_end_state as (
+    select
+        day_rows.match_date,
+        sts.ratings
+    from day_ends as day_rows
+    inner join elo_state as sts on day_rows.match_number = sts.match_number
 )
 
-SELECT
-    dst.match_date AS as_of_date,
-    e.key AS artist_id,
-    e.value AS elo_rating
-FROM day_end_state AS dst, UNNEST(map_entries(dst.ratings)) AS t(e)
+select
+    dst.match_date as as_of_date,
+    entry.key as artist_id,
+    entry.value as elo_rating
+from day_end_state as dst, unnest(map_entries(dst.ratings)) as rating_entries (entry)

--- a/dbt/models/mart/ranking_live.sql
+++ b/dbt/models/mart/ranking_live.sql
@@ -16,31 +16,35 @@
 --
 -- No ORDER BY: an outer SELECT isn't guaranteed to preserve a view's internal
 -- ordering, so callers sort explicitly.
-WITH wins AS (
-    SELECT winner_id AS artist_id, count(*) AS wins
-    FROM {{ source('raw', 'results') }}
-    GROUP BY 1
+with wins as (
+    select
+        winner_id as artist_id,
+        count(*) as wins
+    from {{ source('raw', 'results') }}
+    group by 1
 ),
 
-losses AS (
-    SELECT loser_id AS artist_id, count(*) AS losses
-    FROM {{ source('raw', 'results') }}
-    GROUP BY 1
+losses as (
+    select
+        loser_id as artist_id,
+        count(*) as losses
+    from {{ source('raw', 'results') }}
+    group by 1
 )
 
-SELECT
-    r.artist_id,
-    r.artist_name,
-    r.monthly_listeners,
-    r.image_url,
-    coalesce(w.wins, 0) AS wins,
-    coalesce(l.losses, 0) AS losses,
-    coalesce(w.wins, 0)::DOUBLE
-        / nullif(coalesce(w.wins, 0) + coalesce(l.losses, 0), 0) AS win_rate,
-    coalesce(e.elo_rating, 1500) AS elo_rating
-FROM {{ ref('rappers') }} AS r
-LEFT JOIN wins AS w USING (artist_id)
-LEFT JOIN losses AS l USING (artist_id)
-LEFT JOIN {{ ref('elo') }} AS e USING (artist_id)
+select
+    rap.artist_id,
+    rap.artist_name,
+    rap.monthly_listeners,
+    rap.image_url,
+    coalesce(win_counts.wins, 0) as wins,
+    coalesce(loss_counts.losses, 0) as losses,
+    coalesce(win_counts.wins, 0)::double
+    / nullif(coalesce(win_counts.wins, 0) + coalesce(loss_counts.losses, 0), 0) as win_rate,
+    coalesce(elo_ratings.elo_rating, 1500) as elo_rating
+from {{ ref('rappers') }} as rap
+left join wins as win_counts on rap.artist_id = win_counts.artist_id
+left join losses as loss_counts on rap.artist_id = loss_counts.artist_id
+left join {{ ref('elo') }} as elo_ratings on rap.artist_id = elo_ratings.artist_id
 -- fewer than 5 matches isn't a record yet
-WHERE coalesce(w.wins, 0) + coalesce(l.losses, 0) >= 5
+where coalesce(win_counts.wins, 0) + coalesce(loss_counts.losses, 0) >= 5

--- a/dbt/models/mart/rappers.sql
+++ b/dbt/models/mart/rappers.sql
@@ -1,6 +1,6 @@
 -- genres are no longer available per-artist; genre relevance comes from the
 -- discovery seed, surfaced as flag_core_genre in staging.
-SELECT
+select
     artist_id,
     artist_name,
     monthly_listeners,
@@ -9,5 +9,6 @@ SELECT
     seeds,
     flag_core_genre,
     image_url,
-    load_date
-FROM {{ ref('stg_rappers') }}
+    first_seen_at,
+    last_seen_at
+from {{ ref('stg_rappers') }}

--- a/dbt/models/mart/rappers_filtered.sql
+++ b/dbt/models/mart/rappers_filtered.sql
@@ -8,7 +8,26 @@
 -- that drop out -- genre-filtered at ingestion, fallen below the thresholds,
 -- or delisted -- actually disappear from matchups instead of lingering.
 -- popularity (0-100) is gone; filter on monthly_listeners instead.
-SELECT
+--
+-- "Dropped out" now means ABSENT FOR A WHILE, not absent once. Ingestion is a
+-- scrape of Spotify's internal endpoints, so a rate-limited run loses a random
+-- ~5% of artists; the old rebuild-from-today's-rows read that as a delisting
+-- and pulled real artists (Pusha T, Denzel Curry) out of battles overnight.
+-- stg_rappers keeps each artist's last good observation, and the window below
+-- is what actually retires them:
+--
+--   1 bad run    -> artist stays, on slightly stale listener counts
+--   14 bad runs  -> artist retires from the pool
+--   real delist  -> gone within 14 days
+--
+-- The app reads the battle pool (random matchups and bracket seeding alike)
+-- only through here, so there's one definition of "eligible". The
+-- *_ranking_live views deliberately read mart.rappers instead: a retired
+-- artist's wins were still really won, so their leaderboard row outlives their
+-- eligibility rather than orphaning the votes.
+{% set staleness_window_days = 14 %}
+
+select
     artist_id,
     artist_name,
     monthly_listeners,
@@ -16,8 +35,10 @@ SELECT
     world_rank,
     seeds,
     image_url,
-    load_date
-FROM {{ ref('rappers') }}
-WHERE flag_core_genre = TRUE
-AND monthly_listeners > 1000000
-AND followers > 100000
+    first_seen_at,
+    last_seen_at
+from {{ ref('rappers') }}
+where flag_core_genre = true
+    and monthly_listeners > 1000000
+    and followers > 100000
+    and last_seen_at >= current_date - interval {{ staleness_window_days }} day

--- a/dbt/models/mart/schema.yaml
+++ b/dbt/models/mart/schema.yaml
@@ -67,8 +67,12 @@ models:
           - not_null
       - name: image_url
         description: "URL for the artist's profile picture on Spotify"
-      - name: load_date
-        description: "Timestamp for when the record was initially loaded to Postgres"
+      - name: first_seen_at
+        description: "load_date of the earliest run that ingested this artist"
+        tests:
+          - not_null
+      - name: last_seen_at
+        description: "load_date of the most recent run that ingested this artist. Stale rows survive here on purpose; rappers_filtered is where they're retired."
         tests:
           - not_null
 
@@ -100,13 +104,18 @@ models:
           - not_null
       - name: playcount
         description: "Spotify play count for the track"
-      - name: load_date
-        description: "Timestamp for when the record was initially loaded to Postgres"
+      - name: last_seen_at
+        description: "load_date of the run this track set came from"
         tests:
           - not_null
 
   - name: rappers_filtered
-    description: "Artists filtered by monthly_listeners, core-genre seed and followers"
+    description: >
+      Artists eligible for battles: core-genre seed, monthly_listeners > 1M,
+      followers > 100k, and seen by ingestion within the last 14 days. The
+      staleness window is the resilience knob -- one failed scrape no longer
+      pulls an artist out of the pool, a genuine delisting still clears within
+      two weeks.
     columns:
       - name: artist_id
         description: "Spotify's artist_id identifier"
@@ -131,8 +140,12 @@ models:
         description: "Comma-separated discovery seeds that surfaced the artist"
       - name: image_url
         description: "URL for the artist's profile picture on Spotify"
-      - name: load_date
-        description: "Timestamp for when the record was initially loaded to Postgres"
+      - name: first_seen_at
+        description: "load_date of the earliest run that ingested this artist"
+        tests:
+          - not_null
+      - name: last_seen_at
+        description: "load_date of the most recent run that ingested this artist. Always within the 14-day staleness window at this layer."
         tests:
           - not_null
 

--- a/dbt/models/mart/top_tracks.sql
+++ b/dbt/models/mart/top_tracks.sql
@@ -1,9 +1,9 @@
-SELECT 
+select
     artist_id,
     track_rank,
     track_name,
     track_id,
     track_url,
     playcount,
-    load_date
-FROM {{ ref('stg_top_tracks') }}
+    last_seen_at
+from {{ ref('stg_top_tracks') }}

--- a/dbt/models/staging/schema.yaml
+++ b/dbt/models/staging/schema.yaml
@@ -11,7 +11,11 @@ sources:
 
 models:
   - name: stg_rappers
-    description: "Basically casting load_date to proper timestamp format"
+    description: >
+      One row per artist: their most recent observation out of the append-only
+      raw.rappers history, plus first_seen_at / last_seen_at. Keeping the last
+      good row is what stops a transient ingestion failure from deleting an
+      artist downstream.
     columns:
       - name: artist_id
         description: "Spotify's artist_id identifier"
@@ -38,13 +42,19 @@ models:
           - not_null
       - name: image_url
         description: "URL for the artist's profile picture on Spotify"
-      - name: load_date
-        description: "Timestamp for when the record was initially loaded to Postgres"
+      - name: first_seen_at
+        description: "load_date of the earliest run that ingested this artist"
+        tests:
+          - not_null
+      - name: last_seen_at
+        description: "load_date of the most recent run that ingested this artist -- the staleness clock for mart.rappers_filtered"
         tests:
           - not_null
 
   - name: stg_top_tracks
-    description: "Basically casting load_date to proper timestamp format"
+    description: >
+      Every track from each artist's most recent observation out of the
+      append-only raw.top_tracks history (older snapshots dropped).
     columns:
       - name: artist_id
         description: "Spotify's artist_id identifier"
@@ -68,8 +78,8 @@ models:
           - not_null
       - name: playcount
         description: "Spotify play count for the track"
-      - name: load_date
-        description: "Timestamp for when the record was initially loaded to Postgres"
+      - name: last_seen_at
+        description: "load_date of the run this track set came from"
         tests:
           - not_null
 

--- a/dbt/models/staging/stg_bracket_results.sql
+++ b/dbt/models/staging/stg_bracket_results.sql
@@ -7,27 +7,27 @@
 -- Unlike raw.results, raw.bracket_results has no natural per-row id (see
 -- recordBracketVote in frontend/lib/data.ts), so hash the natural key into
 -- one for incremental merging.
-WITH results AS
-(
-    SELECT
-        md5(run_id || winner_id || loser_id || CAST(voted_at AS VARCHAR)) AS bracket_result_id,
+with results as (
+    select
+        md5(run_id || winner_id || loser_id || cast(voted_at as varchar)) as bracket_result_id,
         run_id,
         matches_in_round,
         winner_id,
         loser_id,
-        CAST(voted_at AS TIMESTAMP) AS voted_at,
-        ROW_NUMBER() OVER (PARTITION BY run_id, winner_id, loser_id, CAST(voted_at AS TIMESTAMP)) AS row_number
-    FROM {{ source('raw', 'bracket_results') }}
+        cast(voted_at as timestamp) as voted_at,
+        row_number() over (partition by run_id, winner_id, loser_id, cast(voted_at as timestamp)) as row_number
+    from {{ source('raw', 'bracket_results') }}
 )
-SELECT
+
+select
     bracket_result_id,
     run_id,
     matches_in_round,
     winner_id,
     loser_id,
     voted_at
-FROM results
-WHERE row_number = 1
+from results
+where row_number = 1
 {% if is_incremental() %}
     AND voted_at > (select coalesce(max(voted_at), timestamp '1900-01-01') from {{ this }})
 {% endif %}

--- a/dbt/models/staging/stg_rappers.sql
+++ b/dbt/models/staging/stg_rappers.sql
@@ -1,4 +1,26 @@
-SELECT
+-- raw.rappers is append-only: one snapshot row per artist per ingestion run.
+-- Collapse that to the artist's MOST RECENT observation, and carry when they
+-- were first and last seen.
+--
+-- last_seen_at is the point of the whole thing: an artist missing from today's
+-- run (transient 429, Spotify hiccup) keeps their last good row instead of
+-- vanishing from the battle pool, and mart.rappers_filtered ages them out only
+-- once they've been gone long enough to mean it.
+with observations as (
+    select
+        artist_id,
+        artist_name,
+        monthly_listeners,
+        followers,
+        world_rank,
+        seeds,
+        flag_core_genre,
+        image_url,
+        cast(load_date as timestamp) as load_date
+    from {{ source('raw', 'rappers') }}
+)
+
+select
     artist_id,
     artist_name,
     monthly_listeners,
@@ -7,5 +29,8 @@ SELECT
     seeds,
     flag_core_genre,
     image_url,
-    CAST(load_date AS TIMESTAMP) AS load_date
-FROM {{ source('raw', 'rappers') }}
+    min(load_date) over (partition by artist_id) as first_seen_at,
+    -- the surviving row is the latest one, so its load_date IS the max
+    load_date as last_seen_at
+from observations
+qualify row_number() over (partition by artist_id order by load_date desc) = 1

--- a/dbt/models/staging/stg_results.sql
+++ b/dbt/models/staging/stg_results.sql
@@ -4,23 +4,23 @@
         unique_key='matchup_id'
     )
 }}
-WITH results AS
-(
-    SELECT 
+with results as (
+    select
         matchup_id,
         winner_id,
         loser_id,
-        CAST(voted_at AS TIMESTAMP) AS voted_at,
-        ROW_NUMBER() OVER(PARTITION BY winner_id, loser_id, CAST(voted_at AS TIMESTAMP)) AS row_number
-    FROM {{ source('raw', 'results') }}
+        cast(voted_at as timestamp) as voted_at,
+        row_number() over (partition by winner_id, loser_id, cast(voted_at as timestamp)) as row_number
+    from {{ source('raw', 'results') }}
 )
-SELECT
+
+select
     matchup_id,
     winner_id,
     loser_id,
     voted_at
-FROM results
-WHERE row_number = 1
+from results
+where row_number = 1
 {% if is_incremental() %}
     -- coalesce so an empty table (max = NULL) loads everything, not nothing
     AND voted_at > (select coalesce(max(voted_at), timestamp '1900-01-01') from {{ this }})

--- a/dbt/models/staging/stg_top_tracks.sql
+++ b/dbt/models/staging/stg_top_tracks.sql
@@ -1,9 +1,33 @@
-SELECT 
+-- raw.top_tracks is append-only alongside raw.rappers, so keep every track
+-- from each artist's most recent observation and drop the older snapshots.
+-- Filtering on the max per ARTIST (not one row per artist) is what preserves
+-- the full top-10 set, and it means an artist surviving on staleness still has
+-- tracks to play in a battle.
+--
+-- Compared at DAY granularity on purpose. Ingestion writes one snapshot per day
+-- (it deletes the day's rows before inserting), and matching on the exact
+-- timestamp would silently keep a single track per artist the moment two rows of
+-- one run disagree by a microsecond -- which is exactly what a `now()` inside
+-- executemany does. tests/assert_top_tracks_keeps_full_latest_set.sql guards it.
+with observations as (
+    select
+        artist_id,
+        track_rank,
+        track_name,
+        track_id,
+        track_url,
+        playcount,
+        cast(load_date as timestamp) as load_date
+    from {{ source('raw', 'top_tracks') }}
+)
+
+select
     artist_id,
     track_rank,
     track_name,
     track_id,
     track_url,
     playcount,
-    CAST(load_date AS TIMESTAMP) AS load_date
-FROM {{ source('raw', 'top_tracks') }}
+    load_date as last_seen_at
+from observations
+qualify cast(load_date as date) = max(cast(load_date as date)) over (partition by artist_id)

--- a/dbt/snapshots/rappers_snapshot.sql
+++ b/dbt/snapshots/rappers_snapshot.sql
@@ -8,11 +8,10 @@
         )
     }}
 
-SELECT
-  artist_id,
-  monthly_listeners,
-  followers,
-  load_date
-FROM {{ ref('rappers_filtered') }}
-
+select
+    artist_id,
+    monthly_listeners,
+    followers,
+    last_seen_at
+from {{ ref('rappers_filtered') }}
 {% endsnapshot %}

--- a/dbt/tests/assert_elo_daily_has_no_open_day.sql
+++ b/dbt/tests/assert_elo_daily_has_no_open_day.sql
@@ -2,7 +2,9 @@
 -- after current_date means a partial day got frozen, and every vote cast later
 -- that day would be skipped forever (the next run's watermark is already past
 -- it). Silent data loss, so fail loudly instead.
-SELECT as_of_date, count(*) AS artists
-FROM {{ ref('elo_daily') }}
-WHERE as_of_date >= current_date
-GROUP BY as_of_date
+select
+    as_of_date,
+    count(*) as artists
+from {{ ref('elo_daily') }}
+where as_of_date >= current_date
+group by as_of_date

--- a/dbt/tests/assert_elo_daily_one_row_per_artist_day.sql
+++ b/dbt/tests/assert_elo_daily_one_row_per_artist_day.sql
@@ -1,10 +1,10 @@
 -- elo_daily's grain is (as_of_date, artist_id). A duplicate means an incremental
 -- run re-emitted a day that was already checkpointed, which would double-count
 -- that day's matches for anyone reading the history series.
-SELECT
+select
     as_of_date,
     artist_id,
-    count(*) AS rows_for_grain
-FROM {{ ref('elo_daily') }}
-GROUP BY as_of_date, artist_id
-HAVING count(*) > 1
+    count(*) as rows_for_grain
+from {{ ref('elo_daily') }}
+group by as_of_date, artist_id
+having count(*) > 1

--- a/dbt/tests/assert_top_tracks_keeps_full_latest_set.sql
+++ b/dbt/tests/assert_top_tracks_keeps_full_latest_set.sql
@@ -1,0 +1,42 @@
+-- mart.top_tracks must carry an artist's WHOLE latest track set, not just one row
+-- of it. raw.top_tracks is append-only, so staging picks the artist's most recent
+-- snapshot -- and if that "most recent" comparison is ever done at a finer
+-- granularity than the run actually stamps (a `now()` evaluated per row inside
+-- executemany gives every row its own microsecond), every artist silently
+-- collapses to a single track. Battles would still render, just with one track
+-- and no hover preview, which is why this needs a test rather than a code comment.
+with latest_day as (
+    select
+        artist_id,
+        max(cast(load_date as date)) as load_day
+    from {{ source('raw', 'top_tracks') }}
+    group by artist_id
+),
+
+expected as (
+    select
+        raw_tracks.artist_id,
+        count(*) as expected_tracks
+    from {{ source('raw', 'top_tracks') }} as raw_tracks
+    inner join latest_day
+        on
+        raw_tracks.artist_id = latest_day.artist_id
+        and cast(raw_tracks.load_date as date) = latest_day.load_day
+    group by raw_tracks.artist_id
+),
+
+actual as (
+    select
+        artist_id,
+        count(*) as actual_tracks
+    from {{ ref('top_tracks') }}
+    group by artist_id
+)
+
+select
+    expected.artist_id,
+    expected.expected_tracks,
+    coalesce(actual.actual_tracks, 0) as actual_tracks
+from expected
+left join actual on expected.artist_id = actual.artist_id
+where coalesce(actual.actual_tracks, 0) != expected.expected_tracks

--- a/ingestion/artist_lister.py
+++ b/ingestion/artist_lister.py
@@ -7,8 +7,12 @@ genres): every artist carries the set of seeds that surfaced them, e.g.
 {"rap", "Rap Caviar"}. Enrichment fetches each artist once, in parallel.
 """
 
+import random
+import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+
+from spotapi.exceptions import ArtistError, BaseClientError, RequestError
 
 from ingestion.spotify_client import SpotifyClient
 from ingestion.spotify_dicts import denylist, loose_seeds
@@ -16,6 +20,18 @@ from ingestion.spotify_dicts import denylist, loose_seeds
 # all configured seeds are curated hip-hop, so an artist is "core" as long as
 # at least one of their seeds isn't a noise-prone loose seed (case-insensitive)
 _LOOSE = {s.lower() for s in loose_seeds}
+
+# Spotify rate-limits the pathfinder endpoint, and with max_workers in flight a
+# burst of 429s is routine -- the 2026-07-27 run lost 29 artists (Pusha T,
+# Denzel Curry, Bad Bunny...) to one-shot failures that all succeed on retry.
+# Jitter matters here (unlike the hash bootstrap, which is a single chain):
+# without it every worker that got throttled retries in lockstep.
+_FETCH_ATTEMPTS = 3
+_FETCH_BACKOFF = 2  # seconds, doubled per retry, plus up to 1s of jitter
+
+# transient at the HTTP layer -- worth retrying. anything else (a malformed
+# payload, a missing key) will fail identically on every attempt, so skip fast.
+_RETRYABLE = (ArtistError, BaseClientError, RequestError)
 
 
 def _is_core(seeds):
@@ -69,11 +85,20 @@ class ArtistLister:
         """
 
         def work(aid):
-            try:
-                return aid, self.client.fetch_artist(aid)
-            except Exception as e:  # skip artists the scrape can't resolve
-                print(f"skip artist {aid} ({artist_dict[aid]['name']}): {e}")
-                return aid, None
+            name = artist_dict[aid]["name"]
+            for attempt in range(1, _FETCH_ATTEMPTS + 1):
+                try:
+                    return aid, self.client.fetch_artist(aid)
+                except _RETRYABLE as e:
+                    # spotapi keeps the HTTP status on .error and out of str(e)
+                    detail = getattr(e, "error", None)
+                    if attempt == _FETCH_ATTEMPTS:
+                        print(f"skip artist {aid} ({name}) after {attempt} tries: {e} ({detail})")
+                        return aid, None
+                    time.sleep(_FETCH_BACKOFF * 2 ** (attempt - 1) + random.uniform(0, 1))
+                except Exception as e:  # skip artists the scrape can't resolve
+                    print(f"skip artist {aid} ({name}): {e}")
+                    return aid, None
 
         enriched = {}
         with ThreadPoolExecutor(max_workers=max_workers) as ex:

--- a/ingestion/load_rappers.py
+++ b/ingestion/load_rappers.py
@@ -7,6 +7,7 @@ Run from the repo root:  python -m ingestion.load_rappers
 
 import os
 import time
+from datetime import datetime
 
 import duckdb
 from dotenv import load_dotenv
@@ -59,11 +60,27 @@ def load_to_db(rapper_rows, track_rows, con):
 
     con.execute("CREATE SCHEMA IF NOT EXISTS raw")
 
-    # full-refresh the raw tables; load_date stamped in SQL so every row of a
-    # run shares one timestamp source.
+    # One timestamp for the entire run, bound as a parameter. It CANNOT be
+    # `now()` inside the INSERT: executemany evaluates that per row, which gave
+    # all 5000 track rows distinct microsecond stamps -- and staging picks each
+    # artist's latest snapshot by load_date, so "latest" collapsed to a single
+    # track per artist instead of their top 10.
+    run_ts = datetime.now()
+
+    # The raw tables are APPEND-ONLY: one snapshot row per artist per run, every
+    # row of that run sharing run_ts. They used to be CREATE OR REPLACE, which
+    # meant a single transient
+    # Spotify failure during enrichment erased that artist everywhere
+    # downstream -- the 2026-07-27 run silently dropped Pusha T and 28 others
+    # out of the battle pool. Keeping history lets stg_rappers fall back to an
+    # artist's last good observation and age them out on last_seen_at instead
+    # (see mart/rappers_filtered.sql). ~600 rows/day is nothing to store.
+    #
+    # Re-running on the same day replaces that day's rows rather than stacking
+    # a second snapshot, so a manual re-run stays idempotent.
     con.execute(
         """
-        CREATE OR REPLACE TABLE raw.rappers (
+        CREATE TABLE IF NOT EXISTS raw.rappers (
             artist_id         VARCHAR,
             artist_name       VARCHAR,
             monthly_listeners BIGINT,
@@ -77,8 +94,9 @@ def load_to_db(rapper_rows, track_rows, con):
         """
     )
     if rapper_rows:
+        con.execute("DELETE FROM raw.rappers WHERE load_date::DATE = current_date")
         con.executemany(
-            "INSERT INTO raw.rappers VALUES (?, ?, ?, ?, ?, ?, ?, ?, now()::TIMESTAMP)",
+            "INSERT INTO raw.rappers VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     r["artist_id"],
@@ -89,14 +107,18 @@ def load_to_db(rapper_rows, track_rows, con):
                     r["image_url"],
                     r["seeds"],
                     r["flag_core_genre"],
+                    run_ts,
                 )
                 for r in rapper_rows
             ],
         )
 
+    # append-only for the same reason as raw.rappers -- and it has to be, or an
+    # artist kept alive by the staleness window would show up in a battle with
+    # no tracks and no hover preview at all.
     con.execute(
         """
-        CREATE OR REPLACE TABLE raw.top_tracks (
+        CREATE TABLE IF NOT EXISTS raw.top_tracks (
             artist_id  VARCHAR,
             track_rank BIGINT,
             track_name VARCHAR,
@@ -108,8 +130,9 @@ def load_to_db(rapper_rows, track_rows, con):
         """
     )
     if track_rows:
+        con.execute("DELETE FROM raw.top_tracks WHERE load_date::DATE = current_date")
         con.executemany(
-            "INSERT INTO raw.top_tracks VALUES (?, ?, ?, ?, ?, ?, now()::TIMESTAMP)",
+            "INSERT INTO raw.top_tracks VALUES (?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     t["artist_id"],
@@ -118,6 +141,7 @@ def load_to_db(rapper_rows, track_rows, con):
                     t["track_id"],
                     t["track_url"],
                     _int(t["playcount"]),
+                    run_ts,
                 )
                 for t in track_rows
             ],

--- a/ingestion/spotify_client.py
+++ b/ingestion/spotify_client.py
@@ -17,8 +17,11 @@ this breaks until spotapi ships an update (`pip install -U spotapi`).
 """
 
 import threading
+import time
 
 from spotapi import Artist, Public, PublicPlaylist
+from spotapi.client import BaseClient
+from spotapi.exceptions import BaseClientError, RequestError
 
 TRACK_EMBED = "https://open.spotify.com/embed/track/{}?utm_source=generator"
 
@@ -34,12 +37,63 @@ def _artist():
     return client
 
 
+# ---- GraphQL hash bootstrap ---------------------------------------------
+#
+# Every spotapi call needs the persisted-query sha256 hashes, which spotapi
+# scrapes out of the web player's JS: one 4.5MB pack + ~72 CDN chunks, all
+# fetched serially. It caches the result on the BaseClient *instance*, and
+# each Public.* call and each worker thread builds a fresh instance -- so a
+# run repeats that ~73-request crawl ~24 times. Any single non-200 anywhere
+# in it aborts the whole job with `BaseClientError("Could not get general
+# hashes")`, and spotapi never retries (that's the 2026-07-28 CI failure).
+#
+# So bootstrap once, with retries, and publish the result as a BaseClient
+# class attribute: later instances see `raw_hashes` already set and skip the
+# crawl entirely (they still open their own session for tokens, which is a
+# couple of cheap requests).
+
+_HASH_ATTEMPTS = 4
+_HASH_BACKOFF = 5  # seconds, doubled per retry
+_hash_lock = threading.Lock()
+
+
+def prime_hashes(attempts=_HASH_ATTEMPTS):
+    """Fetch the GraphQL hashes once and share them across all spotapi clients."""
+    with _hash_lock:
+        if BaseClient.raw_hashes:  # _Undefined is falsy
+            return
+
+        for attempt in range(1, attempts + 1):
+            # a fresh Artist each try -- a new TLS session and cookies, in case
+            # the previous one is what Spotify objected to
+            base = Artist().base
+            try:
+                base.get_session()
+                base.get_sha256_hash()
+            except (BaseClientError, RequestError) as exc:
+                # spotapi stores the underlying HTTP error on `.error` and
+                # leaves it out of str(exc), which is why CI logs show a bare
+                # "Could not get general hashes" with no status code
+                detail = getattr(exc, "error", None)
+                print(f"Hash bootstrap attempt {attempt}/{attempts} failed: {exc} ({detail})")
+                if attempt == attempts:
+                    raise
+                time.sleep(_HASH_BACKOFF * 2 ** (attempt - 1))
+                continue
+
+            BaseClient.raw_hashes = base.raw_hashes
+            return
+
+
 def _uri_id(uri):
     """spotify:artist:XXXX -> XXXX (ids come back as either uri or bare id)."""
     return uri.rsplit(":", 1)[-1] if uri else uri
 
 
 class SpotifyClient:
+    def __init__(self):
+        prime_hashes()
+
     # ---- discovery -----------------------------------------------------
 
     def artists_from_playlist(self, playlist_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,12 @@ dependencies = [
 [tool.uv]
 # this is an application, not a library -- don't try to build/install the repo
 package = false
+
+[dependency-groups]
+# SQL linting only -- the daily pipeline installs with `uv sync --no-dev`.
+# sqlfluff-templater-dbt lets sqlfluff compile the project so ref()/source()/
+# macros/{% snapshot %} resolve; config lives in .sqlfluff at the repo root.
+dev = [
+    "sqlfluff>=4.2.2",
+    "sqlfluff-templater-dbt>=4.2.2",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,12 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "sqlfluff" },
+    { name = "sqlfluff-templater-dbt" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dbt-duckdb" },
@@ -78,6 +84,12 @@ requires-dist = [
     { name = "redis" },
     { name = "spotapi" },
     { name = "websockets" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "sqlfluff", specifier = ">=4.2.2" },
+    { name = "sqlfluff-templater-dbt", specifier = ">=4.2.2" },
 ]
 
 [[package]]
@@ -188,6 +200,37 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -250,14 +293,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -457,6 +500,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/f9/9f49b333bd03e9bbc1bcc3cde14b4927239195f374cb88e8f4aee57550be/diff_cover-10.4.1.tar.gz", hash = "sha256:0ec566955c9ee7da2f6cc48fa16fac7f97ad1fc4e50a887ffb9cfe5eb1e831df", size = 108279, upload-time = "2026-07-24T03:58:08.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/71/bce893908031195b86a8222ac46ebf689c69b0ca10670c1893c56eb87d77/diff_cover-10.4.1-py3-none-any.whl", hash = "sha256:dc8f2654c485ec4f16e679b5af6e205783cde71185d4ceb8157662dca2d531e9", size = 59875, upload-time = "2026-07-24T03:58:07.163Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +592,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinja2-simple-tags"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/b7/a2c8a0c60e6f2cb0dbc5020b43df7b0dc9a8fae0767c2f72665a1c7b76c9/jinja2-simple-tags-0.6.1.tar.gz", hash = "sha256:54abf83883dcd13f8fd2ea2c42feeea8418df3640907bd5251dec5e25a6af0e3", size = 9849, upload-time = "2024-03-06T11:52:36.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/05/8fd074379bdfeb5ce1bccf4a8e23e004e1f238938724f743267759da94e3/jinja2_simple_tags-0.6.1-py2.py3-none-any.whl", hash = "sha256:7b7cfa92f6813a1e0f0b61b9efcab60e6793674753e1f784ff270542e80ae20f", size = 5817, upload-time = "2024-03-06T11:52:34.575Z" },
 ]
 
 [[package]]
@@ -871,6 +941,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1252,6 +1340,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/a5ab6f312f24318019170dc485d5421fe4f89e43a98640da50d95a8a7041/regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd", size = 297122, upload-time = "2026-07-19T00:17:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/85/102a81b218298957d4ea7d2f084fae537a71add9d6ff93c8e67284c5f45e/regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797", size = 796708, upload-time = "2026-07-19T00:17:11.542Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/dc136af5629938a037cd2b304c12240e132ec92f38be8ff9cc89af2a1f2d/regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18", size = 865651, upload-time = "2026-07-19T00:17:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/75/67402ae3cd9c8c988a4c805d15ee3eef015e7ca4cb112cf3e640fc1f4153/regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511", size = 911756, upload-time = "2026-07-19T00:17:15.015Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68", size = 801798, upload-time = "2026-07-19T00:17:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/41/e7ecac6edb5722417f85cc67eaf386322fbe8acf6918ec2fdc37c20dd9d0/regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11", size = 776933, upload-time = "2026-07-19T00:17:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/69/03c9b3f058d66403e0ca2c938696e81d51cd4c6d47ec5265f02f96948d9a/regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986", size = 784338, upload-time = "2026-07-19T00:17:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f7/b38ab3d43f284afbb618fcd15d0e77eb786ae461ce1f6bc7494619ddc0f2/regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b", size = 860452, upload-time = "2026-07-19T00:17:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/ff60ef0571121714f3cf9920bc183071e384a10b556d042e0fdb06cc07a5/regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb", size = 765958, upload-time = "2026-07-19T00:17:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0f/bd34021162c0ab47f9a315bd56cd5642e920c8e5668a75ef6c6a6fca590d/regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035", size = 851765, upload-time = "2026-07-19T00:17:26.993Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/a2ca43edade0595cccfdc98636739f536d9e26898e7dbddc2b9e98898953/regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a", size = 789714, upload-time = "2026-07-19T00:17:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/47/e02db4015d424fc83c00ea0ac8c5e5ec14397943de9abf909d5ce3a25931/regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5", size = 267157, upload-time = "2026-07-19T00:17:31.051Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/c780c131f79b42ed22d1bd7da4096c2c35f813e835acd02ef0f018bd892c/regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312", size = 277777, upload-time = "2026-07-19T00:17:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4c/e4d7e086449bdf379d89774bf1f89dc4a41943f3c5a6125a03905b34b5fb/regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d", size = 277136, upload-time = "2026-07-19T00:17:34.803Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/a65293e6e4cf28eb7ee1be5335a5386c40d6742e9f47fafc8fec785e16c7/regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38", size = 296983, upload-time = "2026-07-19T00:17:38.816Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cd/42dfbabff3dfc9603c501c0e2e2c5adbb09d127b267bf5348de0af338c15/regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13", size = 796775, upload-time = "2026-07-19T00:17:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5d/f6a4839f2b934e3eed5973fd07f5929ee97d4c98939fb275ea23c274ee16/regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae", size = 865687, upload-time = "2026-07-19T00:17:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b0/b47d6c36049bc59806a50bd4c86ced70bbe058d787f80281b1d7a9b0e024/regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da", size = 911962, upload-time = "2026-07-19T00:17:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/ff61f28f9273658cfe23acbbac5217221f6519960ed401e61dfdab12bc35/regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15", size = 801817, upload-time = "2026-07-19T00:17:48.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bb/8b4f7f26b333f9f79e1b453613c39bb4776f51d38ae66dd0ba31d6b354ca/regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f", size = 776908, upload-time = "2026-07-19T00:17:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/610110fc5921d380516d03c26b652555f08aa0d23ea78a771231873c3638/regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939", size = 784426, upload-time = "2026-07-19T00:17:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/1ef9e2a83a5947c57ebff0b377cb5727c3d5ec1992317a320d035cd0dbb6/regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96", size = 860600, upload-time = "2026-07-19T00:17:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/02/073af33a3ec149241d11c80acea91e722aa0adbf05addd50f251c4fe89c3/regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220", size = 765950, upload-time = "2026-07-19T00:17:56.041Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/d1e9f819dc394a568ef370cd56cf25394e957a2235f8370f23b576e5a475/regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc", size = 851794, upload-time = "2026-07-19T00:17:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/8ae83eda7579feacdf984e71fb9e70635fb6f832eeddca58427ec4fca926/regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2", size = 789845, upload-time = "2026-07-19T00:17:59.97Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/c195cbfe5a75fdec64d8f6554fd15237b837919d2c61bdc141d7c807b08b/regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404", size = 267135, upload-time = "2026-07-19T00:18:01.958Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/a11de8404b7272b70acb45c1c05987cce60b45d5693da2e176f0e390d564/regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e", size = 277747, upload-time = "2026-07-19T00:18:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/0f5c8eff1b4f1f3d83276d365fccecf666afcc7d947420943bf394d07adb/regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8", size = 277129, upload-time = "2026-07-19T00:18:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/45/bbd038b5e39ee5613a5a689290145b40058cc152c41de9cc23639d2b9734/regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda", size = 299418, upload-time = "2026-07-19T00:18:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/2f5e107cb26c960b781967178899daf2787a7ab151844ed3c01d6fc95474/regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1", size = 811643, upload-time = "2026-07-19T00:18:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d4/a2f963406d7d73a62eed84ba05a258afb6cad1b21aa4517443ce40506b78/regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf", size = 871081, upload-time = "2026-07-19T00:18:14.733Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a3/44be546340bedb15f13063f5e7fe16793ea4d9ea2e805d09bd174ac27724/regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732", size = 917372, upload-time = "2026-07-19T00:18:16.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/e0870b0fd2a40dba0074e4b76e514b21313d37946c9248453e34ec43923e/regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a", size = 816089, upload-time = "2026-07-19T00:18:18.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/957e8e22690ad6634572b39b71f130a6105f4d0718bb16849eac00fff147/regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba", size = 785206, upload-time = "2026-07-19T00:18:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/186e410941e731037c01166069ab86da9f65e8f8110c18009ccf4bd623ee/regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc", size = 800431, upload-time = "2026-07-19T00:18:22.716Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9f/e4e10e023d291d64a33e246610b724493bf1ce98e0e59c9b7c837e5acfb7/regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62", size = 864906, upload-time = "2026-07-19T00:18:24.772Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/ccb20b6be5f1f52a053d1ba2a8f7a077edb9d918248b8490d7506c6832b3/regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1", size = 773559, upload-time = "2026-07-19T00:18:27.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/f3b263cf8fad927dc102891da8502e718b7ff9d19af7a2a07c03865d7188/regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e", size = 857739, upload-time = "2026-07-19T00:18:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/1687bd1b6c2aed5e672ccf845fc11557821fe7366d921b50889ea5ce57bf/regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0", size = 804522, upload-time = "2026-07-19T00:18:31.362Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7c/cc4e7655181b2d9235b704f2c5e19d8eff002bbc437bae59baee0e381aca/regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4", size = 269141, upload-time = "2026-07-19T00:18:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/14/961b4c7b05a2391c32dbc85e27773076671ef8f97f36cec70fe414734c02/regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974", size = 280036, upload-time = "2026-07-19T00:18:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/795644550d788ddbb6dc458c95895f8009978ea6d6ea76b005eb3f45e8c9/regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d", size = 279394, upload-time = "2026-07-19T00:18:37.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/b70ca6c1704f6c7cd32a9e143c86cc5968d10981eca284bad670c245ea7d/regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac", size = 297093, upload-time = "2026-07-19T00:18:41.583Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/1d478e614016045a33feae57446215f9fd65b665a5ceb2f891fb3183bc52/regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3", size = 797214, upload-time = "2026-07-19T00:18:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ae/11b9c9411d92c30e3d2db32df5a31133e4a99a8fc397a604fd08f6c4bffb/regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053", size = 866433, upload-time = "2026-07-19T00:18:47.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/62/2b2efc4992f91d6d204b24c647c9f9412e85379d92b7c0ab9fdae622327e/regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b", size = 911360, upload-time = "2026-07-19T00:18:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/986ceea9aa3da548bf1357cad89b63915ec6d21ec957c8113b29ece567df/regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a", size = 801275, upload-time = "2026-07-19T00:18:51.767Z" },
+    { url = "https://files.pythonhosted.org/packages/15/be/ce9d9534b2cda96eab32c548261224b9b4e220a4126f098f60f42ae7b4cd/regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1", size = 777131, upload-time = "2026-07-19T00:18:54.053Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/58b5c710f2c3929515a25f3a1ca0dad0dcd4518d4fff3cf23bc7adb8dcd2/regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e", size = 785020, upload-time = "2026-07-19T00:18:56.579Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/5fe091935b74f15fe0f97998c215cae418d1c0413f6258c7d4d2e83aa37f/regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12", size = 861263, upload-time = "2026-07-19T00:18:58.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/d60bf82e10841eef62a9e32aac401468f05fddfbcb2942e342b1ba3d2433/regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2", size = 766199, upload-time = "2026-07-19T00:19:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5d/11e64d151b0662b81d6bf644c74dc118d461df85bdf2577fadbbf751788a/regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97", size = 851317, upload-time = "2026-07-19T00:19:03.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/34/532efb87488d90807bae6a443d357ee5e2728a478c597619c8aaa17cc0bd/regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4", size = 789557, upload-time = "2026-07-19T00:19:05.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/3a8d5ca977171ec3ae21a71207d2228b2663bde14d7f7ef0e6363ecf9290/regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa", size = 272531, upload-time = "2026-07-19T00:19:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/8862885e70409de70e8c005f57fb2e7be8d9ef0317250d60f4c9660a300d/regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac", size = 280831, upload-time = "2026-07-19T00:19:09.46Z" },
+    { url = "https://files.pythonhosted.org/packages/08/82/2693e53e29f9104d9de95d37ce4dd826bd32d5f9c0085d3aa6ac042675c4/regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459", size = 281099, upload-time = "2026-07-19T00:19:11.398Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/bbaeca815dc9191c424c94a4fdc5c87c75748a64a6271821212ebdd4e1a3/regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518", size = 299415, upload-time = "2026-07-19T00:19:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5f/40bacf91d0904f812e13bbbab3864604c463eced8afdc54aeaa50492ea95/regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435", size = 811833, upload-time = "2026-07-19T00:19:20.102Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/4902744261f775aeede8b5627314b38482da29cf49a57b66a6fb753246c5/regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0", size = 871270, upload-time = "2026-07-19T00:19:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/16/70/6980c9be6bf21c0a60ed3e0aea39cf419ecf3b08d1d9947bc56e196ef186/regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a", size = 917534, upload-time = "2026-07-19T00:19:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/92/8b2bd872782ce8c42691e39acb38eb8efe014e5ddb78ad7d943d6f197ce9/regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276", size = 816135, upload-time = "2026-07-19T00:19:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/33a602f657bdc4041f17d79f92ab18261d255d91a06117a6e29df023e5e2/regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c", size = 785492, upload-time = "2026-07-19T00:19:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/36/0987cf4cb271680064a70d24a475873775a151d0b7058698a006cb0cae4a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a", size = 800658, upload-time = "2026-07-19T00:19:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/24/c14f31c135e1ba55fa4f9a58ca98d0842512bf6188230763c31c8f449e3b/regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009", size = 865073, upload-time = "2026-07-19T00:19:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/181a12211f22469f24d2de1ebddfe397d2396e2c29013b9a58134a91069a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218", size = 773684, upload-time = "2026-07-19T00:19:35.599Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/bd1a0c1a62251366f8d21f41b1ea3c76994962071b8b6ea42f72d505c0f0/regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966", size = 857769, upload-time = "2026-07-19T00:19:37.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/f7e2dad6756b2fe1fe75dd90a628c3b45f249d39f948dd90cd2476325417/regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44", size = 804546, upload-time = "2026-07-19T00:19:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1427,6 +1603,42 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlfluff"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "diff-cover" },
+    { name = "jinja2" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tblib" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/a3/fa28d6db93930f349a7c99774ae7b4b9c85865a780f98ef1ddeb52abdf5a/sqlfluff-4.2.2.tar.gz", hash = "sha256:0ee2bcd5d704d0bef56bf80b8f0da9b519ab3e9e0bb1d5e6e4b7e3944d3f5606", size = 1017040, upload-time = "2026-06-04T15:36:53.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/ac/227298acc7230cdd56feb108b0f3a42e47f2e0d58bee50e35cd5facab7de/sqlfluff-4.2.2-py3-none-any.whl", hash = "sha256:62dbfbcd33728351043d216767ec017754a24cd8fb624e8321f61a79988b4fa7", size = 1005710, upload-time = "2026-06-04T15:36:51.661Z" },
+]
+
+[[package]]
+name = "sqlfluff-templater-dbt"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dbt-core" },
+    { name = "jinja2-simple-tags" },
+    { name = "sqlfluff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/91/15d2579a260f53186311af1e669c1a9bcf45f785ea3e243332fb4b5b4b07/sqlfluff_templater_dbt-4.2.2.tar.gz", hash = "sha256:72f628eb632db4963ba05e00939bac5b45f49c96cf42a78a04ed3cd9bfae4b85", size = 15498, upload-time = "2026-06-04T15:36:56.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/c6/237083bacdab346af5c7d3bd1122a785641d6239ca0d7dcb2a541546f03a/sqlfluff_templater_dbt-4.2.2-py3-none-any.whl", hash = "sha256:e3b57cc6b803cc348d83bd5db7e778656eb6b90ea8654de90d27679314eb191c", size = 15181, upload-time = "2026-06-04T15:36:54.953Z" },
+]
+
+[[package]]
 name = "sqlglot"
 version = "30.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1454,12 +1666,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two consecutive scheduled runs failed differently for the same underlying reason: `spotapi` scrapes unofficial Spotify endpoints, so partial failure is routine — but the pipeline treated every gap as fact.

- **2026-07-27** succeeded while silently dropping 29 artists (Pusha T, Denzel Curry, Bad Bunny, DMX…) to one-shot pathfinder errors. `raw.rappers` was `CREATE OR REPLACE`, so they vanished from the battle pool.
- **2026-07-28** failed outright in 17s on the GraphQL hash bootstrap: `BaseClientError: Could not get general hashes`.

Both artists and hashes fetch fine on retry — nothing was actually delisted.

## Ingestion resilience

**Hash bootstrap.** Every spotapi call needs the persisted-query sha256 hashes, scraped from the web player JS: one 4.5MB pack + 72 CDN chunks, serially, any non-200 fatal, no retry. spotapi caches them **per BaseClient instance**, and each `Public.*` call and worker thread builds a fresh one — so a run repeated that crawl ~24 times (~1750 fetches). `prime_hashes()` does it once with 4 retries and publishes to `BaseClient`, so later instances skip it: **73 fetches per run, retried.**

**Per-artist retry.** 3 attempts with exponential backoff **+ jitter** (12 workers throttled together would otherwise retry in lockstep), and only for HTTP-layer errors — a malformed payload skips immediately instead of burning retries.

**Error detail.** Both sites now log `exc.error`, which spotapi keeps off `str(exc)`. That's why CI showed a bare message with no status code.

**Durable pool.** `raw.rappers` / `raw.top_tracks` are append-only snapshots (same-day re-runs replace the day, so manual re-runs stay idempotent). Staging collapses to each artist's last good observation and carries `first_seen_at` / `last_seen_at`; `mart.rappers_filtered` retires an artist only after **14 days unseen**:

| | |
|---|---|
| 1 bad run | artist stays, slightly stale listener counts |
| 14 bad runs | artist retires from the pool |
| real delisting | gone within 14 days |

`top_tracks` gets the same treatment — otherwise an artist kept alive by the window shows up in a battle with no tracks and no hover preview, and the existing `relationships` test can't catch it (wrong direction). The `*_ranking_live` views deliberately keep reading `mart.rappers`, so a retired artist keeps the wins they really won instead of orphaning the votes.

## Latent bug this exposed

Verifying the diff, `mart.top_tracks` came out at 505 rows — **one track per artist instead of ten**:

```
raw.top_tracks rows: 5000
distinct load_date values in raw.top_tracks: 5000   <- one per row, microseconds apart
```

`now()` inside `executemany` is evaluated **per row**, so "the artist's latest snapshot" resolved to a single track. Would have shipped silently: battles still render, just with one track and no preview. Fixed three ways — one bound `run_ts` per run, day-granularity comparison in staging, and `assert_top_tracks_keeps_full_latest_set.sql` (negative-tested by deleting 9 of an artist's 10 tracks: fails as intended).

## SQLFluff

`.sqlfluff` is the `bi-*` BigQuery ruleset with three deltas:

| Delta | Why |
|---|---|
| `dialect = duckdb` | MotherDuck is cloud DuckDB |
| `templater = dbt` | jinja can't parse `{% snapshot %}` or resolve the elo macros |
| `max_parse_depth` / `recursion_limit` raised | recursive Elo CTEs nest past the stock 255 guard; they'd be reported unparseable and go unlinted |

Lint-clean: 303 violations resolved. Auto-fix handled layout and capitalisation; by hand — `USING` → explicit `ON` in both live views, aliases to 3+ chars, and `days` renamed (reserved word in the duckdb dialect).

**CI lints, never fixes** (`.github/workflows/sql-lint.yml`, on PRs and main pushes touching `dbt/**`). A bot rewriting SQL on a branch races your own pushes and turns a style nit into a merge conflict; `uv run sqlfluff fix dbt` belongs on the machine that wrote the query. The job needs **no MotherDuck token** — the templater only compiles, so `DBT_DUCKDB_PATH` points at a scratch file. Daily pipeline gets `--no-dev` so it doesn't install sqlfluff.

⚠️ The dbt templater renders only one side of `{% if is_incremental() %}`, so `elo_daily`'s incremental branch is invisible to the linter and has to be styled by hand. Noted in the file and in `dbt/README.md`.

## Verification

- **Elo unchanged.** Built the same raw data + 234 casual votes + 27 bracket matches over 6 days twice — linted SQL vs HEAD's — and diffed `mart.elo` (40 rows), `elo_daily` (238), `ranking_live` (40), `bracket_ranking_live` (29), `rappers_filtered` (357), `rappers`, `top_tracks`: **symmetric difference 0 on every one.**
- **Clean run twice.** Ingest (500 artists, 4950 tracks, zero skips) → `dbt build` **84 pass**, then again to exercise the incremental branches → **84 pass**.
- Staleness boundaries (3d kept / 20d retired / exactly-14d kept), same-day idempotency, all three retry paths, and snapshot schema drift against a pre-existing `load_date` column (dbt adds `last_seen_at` alongside, existing rows intact).

Optional prod tidy-up afterwards: `ALTER TABLE snapshots.rappers_snapshot DROP COLUMN load_date;` — dead column, NULL on new rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)